### PR TITLE
feat(managed-data): support for getting cell data

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ repo=$(shell basename $(CURDIR))
 
 
 test: 
-	python -m coverage run -m pytest -s -k test_low_level 
+	python -m coverage run -m pytest -s -k test_managed_data 
 	python -m coverage html
 	-open htmlcov/index.html
 	

--- a/tests/test_managed_data.py
+++ b/tests/test_managed_data.py
@@ -93,7 +93,7 @@ def mocker():
 
     tokens = read_cached_do_api_tokens()
 
-    with requests_mock.Mocker(real_http=False) as m:
+    with requests_mock.Mocker(real_http=True) as m:
         m.post(
             urljoin(MOCK_URL, "DescribeRow"),
             json={"data": data},
@@ -221,3 +221,11 @@ def test_download_file(mocker):
 
     # clean up
     os.remove(file_path)
+
+
+def test_test_get_cell_data(mocker):
+    if being_mocked:
+        return
+    data = api.get_cell_data(row_id="dna-1", column_name="Base Sequence")
+
+    assert data == "AAA"


### PR DESCRIPTION
## changes

- [x] some small bug fixes 
- [x] changed name of test to `managed_data` because we test low and high level together
- [x] new function to get data from a single cell
- [x] improvements to get_row_data to preserve cardinality info (see https://deeporigin.slack.com/archives/C06986CSCRJ/p1712930662580189)
