### PR TITLE
feat: shortcut when running in AWS lambda; read config values from env

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -16,12 +16,15 @@ with open(version_filename, "r") as file:
 
     if __version__ == "0.0.0.dev0":
         # in dev mode. we use git to get a "version number"
-        # that will change with tags and commits
-        process = subprocess.run(
-            ["git", "describe", "--tags", "--dirty", "--long"],
-            capture_output=True,
-            universal_newlines=True,
-            cwd=Path(__file__).parent.parent,
-        )
-        if process.returncode == 0:
-            __version__ = process.stdout.strip()
+        # that will change with tags and commits, if possible
+        try:
+            process = subprocess.run(
+                ["git", "describe", "--tags", "--dirty", "--long"],
+                capture_output=True,
+                universal_newlines=True,
+                cwd=Path(__file__).parent.parent,
+            )
+            if process.returncode == 0:
+                __version__ = process.stdout.strip()
+        except Exception:
+            pass

--- a/src/config/__init__.py
+++ b/src/config/__init__.py
@@ -34,6 +34,19 @@ def get_value(
     Returns:
         :obj:`confuse.templates.AttrDict`: configuration for the Deep Origin CLI
     """
+
+    # if we're running on AWS lambda, read config values
+    # from env and return those.
+    if os.environ.get("AWS_LAMBDA_FUNCTION_NAME"):
+        return confuse.AttrDict(
+            dict(
+                organization_id=os.environ.get("DEEP_ORIGIN_ORGANIZATION_ID"),
+                api_endpoint=os.environ.get("DEEP_ORIGIN_API_ENDPOINT"),
+                nucleus_api_route=os.environ.get("DEEP_ORIGIN_NUCLEUS_API_ROUTE"),
+            )
+        )
+
+    # read the default configuration
     value = confuse.Configuration("deep_origin", __name__)
 
     # read the default configuration


### PR DESCRIPTION
## problem

when running in lambda, reading a config file fails for some unknown reason. 

## solution

we shouldn't be reading a config file anyway, introduced a shortcut to read from envs directly 