### PR TITLE
fix: dataframe better matches DB

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,13 +10,23 @@ repo=$(shell basename $(CURDIR))
 client="mock"
 chosen_tests=""
 
+
 test: 
+ifeq ($(client), "mock")
+	source $(CURDIR)/venv/bin/activate && \
+		interrogate -c pyproject.toml -v . -f 100 && \
+		python3 -m coverage run -m pytest -x --failed-first -k $(chosen_tests) --client $(client) && \
+		python3 -m coverage html && \
+		deactivate
+	-open htmlcov/index.html
+else 
 	source $(CURDIR)/venv/bin/activate && \
 		interrogate -c pyproject.toml -v . -f 100 && \
 		python3 -m coverage run -m pytest -x --failed-first -k $(chosen_tests) --client $(client) -n auto && \
 		python3 -m coverage html && \
 		deactivate
 	-open htmlcov/index.html
+endif 
 
 # set up jupyter dev kernel
 jupyter:

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ chosen_tests=""
 test: 
 	source $(CURDIR)/venv/bin/activate && \
 		interrogate -c pyproject.toml -v . -f 100 && \
-		python3 -m coverage run -m pytest -x --failed-first -k $(chosen_tests) --client $(client) && \
+		python3 -m coverage run -m pytest -x --failed-first -k $(chosen_tests) --client $(client) -n auto && \
 		python3 -m coverage html && \
 		deactivate
 	-open htmlcov/index.html

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,8 @@ universal = true
 
 [tool.coverage.run]
 omit = [
-    "src/managed_data/client.py"
+    "src/managed_data/client.py",
+    "tests/*.py",
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ dependencies = [
     "beartype",
     "tabulate",
     "filetype",
-    "pytest-xdist",
 ]
 dynamic = ["version"]
 
@@ -36,6 +35,7 @@ test = [
     "parameterized",
     "coverage",
     "interrogate",
+    "pytest-xdist",
 ]
 jupyter = ["ipykernel","jupyter-black"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "beartype",
     "tabulate",
     "filetype",
+    "pytest-xdist",
 ]
 dynamic = ["version"]
 

--- a/src/auth.py
+++ b/src/auth.py
@@ -154,7 +154,7 @@ def authenticate() -> dict:
             or response.json().get("error", None) != "authorization_pending"
         ):
             raise DeepOriginException(
-                "Sign in to the Deep Origin platform failed. Please try again."
+                message="Sign in to the Deep Origin platform failed. Please try again."
             )
         time.sleep(sign_in_poll_interval_sec)
 

--- a/src/cli/__init__.py
+++ b/src/cli/__init__.py
@@ -5,12 +5,11 @@ import warnings
 import cement
 import termcolor
 from deeporigin import auth
-from deeporigin.config import get_value
-from deeporigin.utils import _print_dict
 
 from .. import __version__
 from ..exceptions import DeepOriginException
 from ..warnings import DeepOriginWarning
+from .config import CONTROLLERS as CONFIG_CONTROLLERS
 from .context import CONTROLLERS as CONTEXT_CONTROLLERS
 from .data import CONTROLLERS as DATA_CONTROLLERS
 from .variables import CONTROLLERS as VARIABLE_CONTROLLERS
@@ -51,27 +50,6 @@ class BaseController(cement.Controller):
         """list the columns of the row and their values, where applicable"""
         auth.get_tokens(refresh=False)
 
-    @cement.ex(
-        help="Show configuration",
-        arguments=[
-            (
-                ["--json"],
-                {
-                    "action": "store_true",
-                    "help": "Whether to return JSON formatted data [default: False]",
-                },
-            ),
-        ],
-    )
-    def config(self):
-        """list the columns of the row and their values, where applicable"""
-
-        data = get_value()
-
-        data.pop("list_bench_variables_query_template", None)
-
-        _print_dict(data, json=self.app.pargs.json)
-
 
 class App(cement.App):
     class Meta:
@@ -82,6 +60,7 @@ class App(cement.App):
             + VARIABLE_CONTROLLERS
             + CONTEXT_CONTROLLERS
             + DATA_CONTROLLERS
+            + CONFIG_CONTROLLERS
         )
 
 

--- a/src/cli/config.py
+++ b/src/cli/config.py
@@ -125,7 +125,10 @@ Show and modify configuration file to connect to Deep Origin
         print(f"✔︎ Configuration loaded from {file_to_load}")
 
         # loading a config should remove api_tokens to trigger a re-authentication
-        os.remove(os.path.expanduser("~/.deeporigin/api_tokens"))
+        try:
+            os.remove(os.path.expanduser("~/.deeporigin/api_tokens"))
+        except FileNotFoundError:
+            pass
 
 
 CONTROLLERS = [

--- a/src/cli/config.py
+++ b/src/cli/config.py
@@ -65,7 +65,7 @@ Show and modify configuration file to connect to Deep Origin
         if key not in TEMPLATE.keys():
             raise DeepOriginException(
                 message=f"{key} is not a valid key for a configuration file.",
-                fix=f" Should be one of {", ".join(list(TEMPLATE.keys()))}",
+                fix=f" Should be one of {', '.join(list(TEMPLATE.keys()))}",
             )
 
         # check if config file exists

--- a/src/cli/config.py
+++ b/src/cli/config.py
@@ -88,7 +88,7 @@ Show and modify configuration file to connect to Deep Origin
         ],
     )
     def save(self):
-        """download or upload files or databases"""
+        """save a config file for later use"""
 
         name = self.app.pargs.name
 
@@ -101,6 +101,31 @@ Show and modify configuration file to connect to Deep Origin
         save_location = os.path.expanduser(f"~/.deeporigin/{name}.yml")
         shutil.copy(CONFIG_YML_LOCATION, save_location)
         print(f"✔︎ Configuration saved to {save_location}")
+
+    @cement.ex(
+        help="Save configuration file for later use",
+        arguments=[
+            (["name"], {"help": "Name to save as", "action": "store"}),
+        ],
+    )
+    def load(self):
+        """load a config file and use it"""
+
+        name = self.app.pargs.name
+
+        file_to_load = os.path.expanduser(f"~/.deeporigin/{name}.yml")
+
+        # check if config file exists
+        if not os.path.isfile(file_to_load):
+            raise DeepOriginException(
+                "Cannot save configuration for later use because no user configuration exists."
+            )
+
+        shutil.copy(file_to_load, CONFIG_YML_LOCATION)
+        print(f"✔︎ Configuration loaded from {file_to_load}")
+
+        # loading a config should remove api_tokens to trigger a re-authentication
+        os.remove(os.path.expanduser("~/.deeporigin/api_tokens"))
 
 
 CONTROLLERS = [

--- a/src/cli/config.py
+++ b/src/cli/config.py
@@ -1,0 +1,82 @@
+"""this implements controllers and hooks to connect to
+managed_data.py"""
+
+import os
+
+import cement
+import yaml
+from deeporigin.config import CONFIG_YML_LOCATION, TEMPLATE, get_value
+from deeporigin.exceptions import DeepOriginException
+from deeporigin.utils import _print_dict
+
+
+class ConfigController(cement.Controller):
+    """Controller for data subcommand of CLI"""
+
+    class Meta:
+        label = "config"
+        stacked_on = "base"
+        stacked_type = "nested"
+        help = "Show and modify configuration"
+        description = """
+Show and modify configuration file to connect to Deep Origin 
+            """
+
+    def _default(self):
+        self.app.pargs.json = False
+        self.show()
+
+    @cement.ex(
+        help="Show configuration",
+        arguments=[
+            (
+                ["--json"],
+                {
+                    "action": "store_true",
+                    "help": "Whether to return JSON formatted data [default: False]",
+                },
+            ),
+        ],
+    )
+    def show(self):
+        """list the columns of the row and their values, where applicable"""
+
+        data = get_value()
+
+        data.pop("list_bench_variables_query_template", None)
+
+        _print_dict(data, json=self.app.pargs.json)
+
+    @cement.ex(
+        help="Set configuration value in config file",
+        arguments=[
+            (["key"], {"help": "Key to set", "action": "store"}),
+            (["value"], {"help": "Value to set", "action": "store"}),
+        ],
+    )
+    def set(self):
+        """download or upload files or databases"""
+
+        key = self.app.pargs.key
+        value = self.app.pargs.value
+
+        # check that key exists in the confuse template
+        if key not in TEMPLATE.keys():
+            raise DeepOriginException(
+                message=f"{key} is not a valid key for a configuration file.",
+                fix=f" Should be one of {", ".join(list(TEMPLATE.keys()))}",
+            )
+
+        # check if config file exists
+        if os.path.isfile(CONFIG_YML_LOCATION):
+            print("need to read file")
+            dsfsdf
+        else:
+            # no file.
+            with open(CONFIG_YML_LOCATION, "w") as file:
+                yaml.dump({key: value}, file, default_flow_style=False)
+
+
+CONTROLLERS = [
+    ConfigController,
+]

--- a/src/cli/config.py
+++ b/src/cli/config.py
@@ -2,6 +2,7 @@
 managed_data.py"""
 
 import os
+import shutil
 
 import cement
 import yaml
@@ -69,12 +70,37 @@ Show and modify configuration file to connect to Deep Origin
 
         # check if config file exists
         if os.path.isfile(CONFIG_YML_LOCATION):
-            print("need to read file")
-            dsfsdf
+            with open(CONFIG_YML_LOCATION, "r") as file:
+                data = yaml.safe_load(file)
+            data[key] = value
         else:
             # no file.
-            with open(CONFIG_YML_LOCATION, "w") as file:
-                yaml.dump({key: value}, file, default_flow_style=False)
+            data = {key: value}
+        with open(CONFIG_YML_LOCATION, "w") as file:
+            yaml.dump(data, file, default_flow_style=False)
+
+        print(f"✔︎ {key} → {value}")
+
+    @cement.ex(
+        help="Save configuration file for later use",
+        arguments=[
+            (["name"], {"help": "Name to save as", "action": "store"}),
+        ],
+    )
+    def save(self):
+        """download or upload files or databases"""
+
+        name = self.app.pargs.name
+
+        # check if config file exists
+        if not os.path.isfile(CONFIG_YML_LOCATION):
+            raise DeepOriginException(
+                "Cannot save configuration for later use because no user configuration exists."
+            )
+
+        save_location = os.path.expanduser(f"~/.deeporigin/{name}.yml")
+        shutil.copy(CONFIG_YML_LOCATION, save_location)
+        print(f"✔︎ Configuration saved to {save_location}")
 
 
 CONTROLLERS = [

--- a/src/cli/config.py
+++ b/src/cli/config.py
@@ -5,6 +5,7 @@ import os
 import shutil
 
 import cement
+import confuse
 import yaml
 from deeporigin.config import CONFIG_YML_LOCATION, TEMPLATE, get_value
 from deeporigin.exceptions import DeepOriginException
@@ -76,6 +77,17 @@ Show and modify configuration file to connect to Deep Origin
         else:
             # no file.
             data = {key: value}
+
+        # check that this is valid
+        config = confuse.Configuration("deep_origin", __name__)
+        config.set(data)
+        try:
+            _ = config.get(TEMPLATE)
+        except confuse.confuse.ConfigError:
+            raise DeepOriginException(
+                f"{key}:{value} is not a valid entry for the configuration.",
+            )
+
         with open(CONFIG_YML_LOCATION, "w") as file:
             yaml.dump(data, file, default_flow_style=False)
 
@@ -84,13 +96,13 @@ Show and modify configuration file to connect to Deep Origin
     @cement.ex(
         help="Save configuration file for later use",
         arguments=[
-            (["name"], {"help": "Name to save as", "action": "store"}),
+            (["profile"], {"help": "Profile to save as", "action": "store"}),
         ],
     )
     def save(self):
         """save a config file for later use"""
 
-        name = self.app.pargs.name
+        name = self.app.pargs.profile
 
         # check if config file exists
         if not os.path.isfile(CONFIG_YML_LOCATION):
@@ -105,13 +117,13 @@ Show and modify configuration file to connect to Deep Origin
     @cement.ex(
         help="Save configuration file for later use",
         arguments=[
-            (["name"], {"help": "Name to save as", "action": "store"}),
+            (["profile"], {"help": "Profile name to save as", "action": "store"}),
         ],
     )
     def load(self):
         """load a config file and use it"""
 
-        name = self.app.pargs.name
+        name = self.app.pargs.profile
 
         file_to_load = os.path.expanduser(f"~/.deeporigin/{name}.yml")
 

--- a/src/exceptions.py
+++ b/src/exceptions.py
@@ -1,7 +1,47 @@
+import sys
+import textwrap
+from typing import Optional
+
+import termcolor
+from tabulate import tabulate
+
 __all__ = ["DeepOriginException"]
+
+
+def _wrap(text: str) -> str:
+    wrapped_message = textwrap.wrap(text)
+    wrapped_message = "\n".join(wrapped_message)
+
+    return wrapped_message
 
 
 class DeepOriginException(Exception):
     """Deep Origin exception"""
 
-    pass
+    def __init__(
+        self,
+        message: str,
+        *,
+        title: str = "Deep Origin Error",
+        fix: Optional[str] = None,
+    ):
+        """utility function to print a nicely formatted error, used in the CLI"""
+
+        self.message = message
+
+        printout = [[title], [_wrap(message)]]
+        if fix:
+            printout.append([_wrap(fix)])
+
+        sys.stderr.write(
+            termcolor.colored(
+                tabulate(
+                    printout,
+                    tablefmt="rounded_grid",
+                ),
+                "red",
+            )
+            + "\n"
+        )
+
+        super().__init__(self.message)

--- a/src/managed_data/_api.py
+++ b/src/managed_data/_api.py
@@ -2,7 +2,6 @@
 with Deep Origin's managed data API. The functions in this module
 simply provide Pythonic interfaces to individual API endpoints."""
 
-
 import os
 from typing import Optional, Union
 from urllib.parse import parse_qs, urlparse

--- a/src/managed_data/_api.py
+++ b/src/managed_data/_api.py
@@ -92,7 +92,7 @@ def upload_file(
         )
 
         if put_response.status_code != 200:
-            raise DeepOriginException("Error uploading file")
+            raise DeepOriginException(message="Error uploading file")
 
     return response["file"]
 
@@ -634,7 +634,9 @@ def download_file(
     client = _get_default_client(client)
 
     if not os.path.isdir(destination):
-        raise DeepOriginException(f"{destination} should be a path to a folder.")
+        raise DeepOriginException(
+            message=f"{destination} should be a path to a folder."
+        )
 
     file_name = describe_file(file_id, client=client)["name"]
 
@@ -656,7 +658,7 @@ def convert_id_format(
 
     if hids is None and ids is None:
         raise DeepOriginException(
-            "Either `hids` or `ids` should be non-None and a list of strings"
+            message="Either `hids` or `ids` should be non-None and a list of strings"
         )
 
     client = _get_default_client(client)

--- a/src/managed_data/_api.py
+++ b/src/managed_data/_api.py
@@ -5,7 +5,7 @@ simply provide Pythonic interfaces to individual API endpoints."""
 
 import os
 from typing import Optional, Union
-from urllib.parse import parse_qs, urlparse, urlunparse
+from urllib.parse import parse_qs, urlparse
 
 from beartype import beartype
 from deeporigin.exceptions import DeepOriginException

--- a/src/managed_data/api.py
+++ b/src/managed_data/api.py
@@ -453,6 +453,11 @@ def get_dataframe(
     # figure out the rows
     rows = _api.list_database_rows(database_id, client=client)
 
+    # filter out template rows
+    rows = [
+        row for row in rows if not ("isTemplate" in row.keys() and row["isTemplate"])
+    ]
+
     # figure out the column names and ID of the database
     response = _api.describe_row(database_id, client=client)
     assert (

--- a/src/managed_data/api.py
+++ b/src/managed_data/api.py
@@ -34,7 +34,7 @@ def make_database_rows(
 
     if n_rows < 1:
         raise DeepOriginException(
-            f"n_rows must be at least 1. However, n_rows was {n_rows}"
+            message=f"n_rows must be at least 1. However, n_rows was {n_rows}"
         )
 
     data = dict(
@@ -248,7 +248,7 @@ def set_cell_data(
 
     if len(column) != 1:
         raise DeepOriginException(
-            f"Could not find column {column_id} in database {database_id}"
+            message=f"Could not find column {column_id} in database {database_id}"
         )
 
     column = column[0]
@@ -261,14 +261,14 @@ def set_cell_data(
             value = [""]
         else:
             raise DeepOriginException(
-                "Attempting to write to a cell that is of type select. Values to be written here should be strings or lists of strings."
+                message="Attempting to write to a cell that is of type select. Values to be written here should be strings or lists of strings."
             )
 
         options = column["configSelect"]["options"]
         for item in value:
             if item not in options:
                 raise DeepOriginException(
-                    f"Expected every item to be in the options list. However, `{item}` is not in {options}"
+                    message=f"Expected every item to be in the options list. However, `{item}` is not in {options}"
                 )
 
         validated_value = dict(selectedOptions=value)
@@ -279,7 +279,7 @@ def set_cell_data(
             validated_value = int(value)
         except ValueError:
             raise DeepOriginException(
-                f"Attempting to write to a cell that is of type integer. Value to be written here should be an integer. Instead, you attempted to write: {value}"
+                message=f"Attempting to write to a cell that is of type integer. Value to be written here should be an integer. Instead, you attempted to write: {value}"
             )
 
     elif column["type"] == "float":
@@ -287,7 +287,7 @@ def set_cell_data(
             validated_value = float(value)
         except ValueError:
             raise DeepOriginException(
-                f"Attempting to write to a cell that is of type float. Value to be written here should be an float. Instead, you attempted to write: {value}"
+                message=f"Attempting to write to a cell that is of type float. Value to be written here should be an float. Instead, you attempted to write: {value}"
             )
 
     elif column["type"] == "boolean":
@@ -295,7 +295,7 @@ def set_cell_data(
             validated_value = value
         else:
             raise DeepOriginException(
-                f"Attempting to write to a cell that is of type boolean. Value to be written here should be a True, False or None. Instead, you attempted to write: {value}"
+                message=f"Attempting to write to a cell that is of type boolean. Value to be written here should be a True, False or None. Instead, you attempted to write: {value}"
             )
     else:
         raise NotImplementedError("This data type is not yet supported")
@@ -347,7 +347,9 @@ def download(
     Path(destination).mkdir(parents=True, exist_ok=True)
 
     if not os.path.isdir(destination):
-        raise DeepOriginException(f"{destination} should be a path to a folder.")
+        raise DeepOriginException(
+            message=f"{destination} should be a path to a folder."
+        )
 
     source = source.replace(PREFIXES.DO, "")
 
@@ -398,13 +400,15 @@ def download_database(
     """
 
     if not os.path.isdir(destination):
-        raise DeepOriginException(f"{destination} should be a path to a folder.")
+        raise DeepOriginException(
+            message=f"{destination} should be a path to a folder."
+        )
 
     if isinstance(source, str):
         source = _api.describe_row(source, client=client)
     elif not {"hid", "id"}.issubset(set(list(source.keys()))):
         raise DeepOriginException(
-            f"If `source` is a dictionary, expected it contain the `hid` and `id` keys. These keys were not found. Instead, the keys are: {source.keys()}"
+            message=f"If `source` is a dictionary, expected it contain the `hid` and `id` keys. These keys were not found. Instead, the keys are: {source.keys()}"
         )
 
     database_id = source["id"]
@@ -704,7 +708,7 @@ def get_row_data(
 
     if response["type"] != "row":
         raise DeepOriginException(
-            f"Expected `row_id` to resolve to a row, instead, it resolves to a `{response['type']}`"
+            message=f"Expected `row_id` to resolve to a row, instead, it resolves to a `{response['type']}`"
         )
 
     # ask parent for column names
@@ -712,7 +716,7 @@ def get_row_data(
 
     if parent_response["type"] != "database":
         raise DeepOriginException(
-            f"Expected parent of `{row_id}` to resolve to a database, instead, it resolves to a `{parent_response['type']}`"
+            message=f"Expected parent of `{row_id}` to resolve to a database, instead, it resolves to a `{parent_response['type']}`"
         )
 
     # make a dictionary from column IDs to column names

--- a/src/managed_data/api.py
+++ b/src/managed_data/api.py
@@ -5,7 +5,6 @@ import os
 from pathlib import Path
 from typing import Any, Optional, Union
 
-import requests
 from beartype import beartype
 from deeporigin.exceptions import DeepOriginException
 from deeporigin.managed_data import _api
@@ -458,12 +457,12 @@ def get_dataframe(
 
     columns = response["cols"]
     database_id = response["id"]
-    row_id = response["hidPrefix"] + "-id"
+    row_id = "ID"
 
     # make a dictionary with all data in the database
     data = dict()
-    data["Validation Status"] = []
     data[row_id] = []
+    data["Validation Status"] = []
 
     # keep track of all files and references in this database
     file_ids = []
@@ -645,7 +644,7 @@ def _type_and_cleanup_dataframe(
     df["numeric_id"] = df[primary_key].apply(lambda x: int(x.split("-")[1]))
     df = df.sort_values(by="numeric_id")
     df = df.drop(columns="numeric_id")
-    df.reset_index(drop=True, inplace=True)
+    df = df.set_index("ID")
 
     return df
 

--- a/src/managed_data/client.py
+++ b/src/managed_data/client.py
@@ -142,7 +142,7 @@ class DeepOriginClient(Client):
 
         with requests.get(url, stream=True) as response:
             if response.status_code != 200:
-                raise DeepOriginException(f"Failed to download file from {url}")
+                raise DeepOriginException(message=f"Failed to download file from {url}")
 
             with open(save_path, "wb") as file:
                 for chunk in response.iter_content(chunk_size=8192):
@@ -183,16 +183,18 @@ def _check_response(response: requests.models.Response) -> Union[dict, list]:
 
     if response.status_code == 404:
         raise DeepOriginException(
-            f"[Error 404] The requested resource was not found. The response was: {response.json()}"
+            message=f"[Error 404] The requested resource was not found. The response was: {response.json()}"
         )
     elif response.status_code == 400:
-        raise DeepOriginException(f"[Error 400] The response was: {response.json()}")
+        raise DeepOriginException(
+            message=f"[Error 400] The response was: {response.json()}"
+        )
 
     response.raise_for_status()
     response = response.json()
 
     if "error" in response:
-        raise DeepOriginException(response["error"])
+        raise DeepOriginException(message=response["error"])
 
     if "data" in response:
         return response["data"]

--- a/src/variables/core.py
+++ b/src/variables/core.py
@@ -78,7 +78,7 @@ def get_variable_types_by_values(values: list[str]) -> list[VariableType]:
                 ),
             ]
         )
-        raise DeepOriginException(msg)
+        raise DeepOriginException(message=msg)
 
     return types
 
@@ -257,7 +257,7 @@ def get_variables_from_do_platform(
         msg = f"{len(invalid_variables)} variables are not valid.\n\n" + "\n\n".join(
             invalid_variables
         )
-        raise DeepOriginException(msg)
+        raise DeepOriginException(message=msg)
 
     # return variables
     return variables
@@ -278,7 +278,9 @@ def deserialize_variable(serialized: dict) -> Variable:
         if cls.value.Meta.platform_id == type_platform_id:
             return cls.value.from_platform(serialized)
 
-    raise DeepOriginException(f"{type} is not a valid type of variable or secret.")
+    raise DeepOriginException(
+        message=f"{type} is not a valid type of variable or secret."
+    )
 
 
 def is_variable_modified(variable: Variable) -> bool:
@@ -463,7 +465,7 @@ def enable_variable_auto_updating(
                 "pytest/__main__.py"
             ):
                 raise DeepOriginException(
-                    "Auto installation must be run from the Deep Origin CLI"
+                    message="Auto installation must be run from the Deep Origin CLI"
                 )
 
         cli_command = [cli, "variables", "install"]

--- a/src/variables/types/aws_profile.py
+++ b/src/variables/types/aws_profile.py
@@ -144,7 +144,7 @@ class AwsProfile(Variable):
 
                 if completed_process.returncode != 0:
                     raise DeepOriginException(
-                        f"AWS profile {self.name or ''} could not be imported: {completed_process.stdout.decode().strip()}"
+                        message=f"AWS profile {self.name or ''} could not be imported: {completed_process.stdout.decode().strip()}"
                     )
         else:
             warnings.warn(
@@ -261,7 +261,7 @@ class AwsProfile(Variable):
 
             if completed_process.returncode != 0:
                 raise DeepOriginException(
-                    f"AWS profile {self.name or ''} could not be uninstalled: {completed_process.stdout.decode().strip()}"
+                    message=f"AWS profile {self.name or ''} could not be uninstalled: {completed_process.stdout.decode().strip()}"
                 )
         else:
             warnings.warn(

--- a/tests/mock_client.py
+++ b/tests/mock_client.py
@@ -204,11 +204,31 @@ class MockClient(client.Client):
             for idx in range(5)
         ]
 
+    def invoke_ensure_rows(self, data):
+        """callback when we invoke EnsureRows"""
+        return {
+            "rows": [
+                {
+                    "id": "_row:RETrlQNnPAPNSC8q21toF",
+                    "parentId": "_database:IpWYEnJE0uIx2TchRVVLQ",
+                    "type": "row",
+                    "dateCreated": "2024-07-03 13:54:09.888684",
+                    "dateUpdated": "2024-07-03 13:54:09.888684",
+                    "createdByUserDrn": "drn:identity::user:google-apps|srinivas@deeporigin.com",
+                    "hid": "dna-12",
+                    "validationStatus": "invalid",
+                }
+            ]
+        }
+
     def invoke(self, endpoint: str, data: dict):
         """simple returns data without making any network requests"""
 
         if endpoint == "ListRows":
             return self.invoke_list_rows(data)
+
+        elif endpoint == "EnsureRows":
+            return self.invoke_ensure_rows(data)
 
         elif endpoint == "CreateWorkspace":
             name = data["workspace"]["name"]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -38,7 +38,7 @@ class TestCase(unittest.TestCase):
         }
         config.get_value.cache_clear()
         with unittest.mock.patch.dict("os.environ", env):
-            value = config.get_value(user_config_filenames=tuple())
+            value = config.get_value()
         expected_value = {
             "organization_id": "a123",
             "bench_id": "b123",
@@ -65,14 +65,14 @@ class TestCase(unittest.TestCase):
         env["DEEP_ORIGIN_FEATURE_FLAGS__VARIABLES"] = "false"
         config.get_value.cache_clear()
         with unittest.mock.patch.dict("os.environ", env):
-            value = config.get_value(user_config_filenames=tuple())
+            value = config.get_value()
         expected_value["feature_flags"] = {"variables": False}
         self.assertEqual(expected_value, value)
 
         env["DEEP_ORIGIN_FEATURE_FLAGS__VARIABLES"] = "true"
         config.get_value.cache_clear()
         with unittest.mock.patch.dict("os.environ", env):
-            value = config.get_value(user_config_filenames=tuple())
+            value = config.get_value()
         expected_value["feature_flags"]["variables"] = True
         self.assertEqual(expected_value, value)
 
@@ -103,7 +103,7 @@ class TestCase(unittest.TestCase):
             yaml.dump(user_config, file, Dumper=yaml.CDumper)
 
         with unittest.mock.patch.dict("os.environ", env):
-            value = config.get_value(user_config_filenames=(user_config_filename,))
+            value = config.get_value(user_config_filename)
 
         user_config["api_tokens_filename"] = os.path.expanduser(
             user_config["api_tokens_filename"]
@@ -146,7 +146,5 @@ class TestCase(unittest.TestCase):
             yaml.dump(user_config, file, Dumper=yaml.CDumper)
 
         with unittest.mock.patch.dict("os.environ", env):
-            with self.assertRaisesRegex(
-                DeepOriginException, "configuration is not valid"
-            ):
-                config.get_value(user_config_filenames=(user_config_filename,))
+            with self.assertRaisesRegex(DeepOriginException, "The Deep Origin CLI"):
+                config.get_value("/nonexistent.file")

--- a/tests/test_managed_data.py
+++ b/tests/test_managed_data.py
@@ -73,6 +73,14 @@ def test_make_database_rows(config):
             client=config["client"],
         )
 
+    response = api.make_database_rows(
+        config["databases"][0],
+        client=config["client"],
+    )
+
+    for row in response["rows"]:
+        assert row["type"] == "row", "Expected rows to be created."
+
 
 def test_create_workspace(config):
     data = _api.create_workspace(

--- a/tests/test_managed_data.py
+++ b/tests/test_managed_data.py
@@ -67,7 +67,7 @@ def config(pytestconfig):
 
 def test_make_database_rows(config):
     with pytest.raises(DeepOriginException, match="must be at least 1"):
-        data = api.make_database_rows(
+        api.make_database_rows(
             config["databases"][0],
             n_rows=0,
             client=config["client"],
@@ -285,10 +285,6 @@ def test_get_dataframe(config):
     assert (
         "Validation Status" in df.columns
     ), f"Expected to find a column called `Validation Status` in the dataframe. Instead, the columns in this dataframe are: {df.columns}"
-
-    assert (
-        df.attrs["primary_key"] in df.columns
-    ), "Expected to find the primary key as a column"
 
     data = api.get_dataframe(
         config["databases"][0],


### PR DESCRIPTION
## changes

- [x] ID column is called ID in dataframe
- [x] ID column is the index in dataframe
- [x] fixed coverage to exclude test files
- [x] upgraded DeepOriginException to pretty print errors, including suggestions on how to fix it
- [x] `deeporigin config` can now show, save and load configs. 
- [x] refactored config.get_value() to only work with one file location, because having more than one was needlessly complex and was unused. 
- [x] slightly improved coverage (will improve after switching to low-level generated code)

## examples/screenshots

```
❯ deeporigin config load prod
✔︎ Configuration loaded from /Users/srinivas/.deeporigin/prod.yml
```


pretty errors:

```
❯ deeporigin data list
╭──────────────────────────────────────────────────────────────────────╮
│ Invalid configuration                                                │
├──────────────────────────────────────────────────────────────────────┤
│ The Deep Origin CLI and python client requires a valid configuration │
│ file. This field is not valid:  organization_id: must be a string    │
├──────────────────────────────────────────────────────────────────────┤
│ To fix, run `deeporigin config set organization_id <value>`          │
╰──────────────────────────────────────────────────────────────────────╯
```


