### PR TITLE
feat: disabled printing context for compute cluster and hardware which the platform no longer provides

### DIFF
--- a/docs/how-to/do-info.md
+++ b/docs/how-to/do-info.md
@@ -51,8 +51,6 @@ and you will see a table that looks like this:
 Bench ID: average-possum-3x3
 User ID: None
 Organization ID: likely-aardvark-ewo
-Host: None
-Hardware: None
 Environment: edge
 Debug: False
 ```
@@ -65,8 +63,6 @@ Debug: False
     Bench ID: None
     User ID: None
     Organization ID: None
-    Host: None
-    Hardware: None
     Environment: None
     Debug: False
     ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,9 @@ dependencies = [
 dynamic = ["version"]
 
 [project.optional-dependencies]
+lint = [
+    "ruff",
+]
 test = [
     "pytest",
     "parameterized",
@@ -37,9 +40,12 @@ test = [
     "interrogate",
     "pytest-xdist",
 ]
-jupyter = ["ipykernel","jupyter-black"]
-
-docs = ["mkdocs", 
+jupyter = [
+    "ipykernel",
+    "jupyter-black",
+]
+docs = [
+    "mkdocs", 
     "mkdocs-material-extensions", 
     "mkdocs-material", 
     "mkdocstrings",

--- a/src/cli/context.py
+++ b/src/cli/context.py
@@ -18,7 +18,7 @@ class ContextController(cement.Controller):
         stacked_on = "base"
         stacked_type = "nested"
         help = "Get the context for the Deep Origin ComputeBench"
-        description = "Get the context for the Deep Origin ComputeBench, such as the ID of the bench, user and organization, host, and hardware blueprint."
+        description = "Get the context for the Deep Origin ComputeBench, such as the ID of the bench, user and organization, host compute cluster, and hardware blueprint."
         arguments = []
 
     @cement.ex(hide=True)
@@ -33,18 +33,18 @@ class ContextController(cement.Controller):
         print(f"User ID: {context.user_id}")
         print(f"Organization ID: {context.org_id}")
 
-        # host
-        if context.host:
-            print("Host:")
-            print(f"  ID: {context.host.id}")
-            if context.host.properties:
+        # host compute cluster
+        if context.compute_cluster:
+            print("Compute cluster:")
+            print(f"  ID: {context.compute_cluster.id}")
+            if context.compute_cluster.properties:
                 print("  Properties:")
-                for key, value in context.host.properties.items():
+                for key, value in context.compute_cluster.properties.items():
                     print(f"    {key}: {value}")
             else:
                 print(f"  Properties: {None}")
         else:
-            print(f"Host: {None}")
+            print(f"Compute cluster: {None}")
 
         # hardware
         if context.hardware:

--- a/src/cli/context.py
+++ b/src/cli/context.py
@@ -25,78 +25,7 @@ class ContextController(cement.Controller):
     def _default(self):
         """Default action. returns the context"""
         context = get_context()
-
-        # bench id
-        print(f"Bench ID: {context.bench_id}")
-
-        # user and organization
-        print(f"User ID: {context.user_id}")
-        print(f"Organization ID: {context.org_id}")
-
-        # host compute cluster
-        if context.compute_cluster:
-            print("Compute cluster:")
-            print(f"  ID: {context.compute_cluster.id}")
-            if context.compute_cluster.properties:
-                print("  Properties:")
-                for key, value in context.compute_cluster.properties.items():
-                    print(f"    {key}: {value}")
-            else:
-                print(f"  Properties: {None}")
-        else:
-            print(f"Compute cluster: {None}")
-
-        # hardware
-        if context.hardware:
-            print("Hardware:")
-
-            # CPU
-            if context.hardware.cpu:
-                print("  Processing:")
-                if context.hardware.cpu.quantity_vcpu is not None:
-                    print(
-                        f"    Quantity: {context.hardware.cpu.quantity_vcpu:.1f} vCPU"
-                    )
-                else:
-                    print("    Quantity: N/A")
-                print(f"    Architecture: {context.hardware.cpu.architecture or 'N/A'}")
-                if context.hardware.cpu.memory_gb is not None:
-                    print(f"    Memory: {context.hardware.cpu.memory_gb:.1f} GB")
-                else:
-                    print("    Memory: N/A")
-            else:
-                print("  Processing: N/A")
-
-            # GPU
-            if context.hardware.gpu:
-                print("  Accelerated processing:")
-                if context.hardware.gpu.quantity_gpu is not None:
-                    print(f"    Quantity: {context.hardware.gpu.quantity_gpu:.1f} GPU")
-                else:
-                    print("    Quantity: None")
-                if context.hardware.gpu.architecture:
-                    print("    Architecture:")
-                    print(f"      Vendor: {context.hardware.gpu.architecture.vendor}")
-                    print(
-                        f"      Microarchitecture: {context.hardware.gpu.architecture.microarchitecture}"
-                    )
-                    print(f"      Model: {context.hardware.gpu.architecture.model}")
-                else:
-                    print(f"    Architecture: {None}")
-                if context.hardware.gpu.memory_gb is not None:
-                    print(f"    Memory: {context.hardware.gpu.memory_gb:.1f} GB")
-                else:
-                    print("    Memory: None")
-            else:
-                print(f"  Accelerated processing: {None}")
-        else:
-            print(f"Hardware: {None}")
-
-        # environment
-        print(f"Environment: {context.env}")
-
-        # debug
-        print(f"Debug: {context.debug}")
+        print(context)
 
 
 CONTROLLERS = [

--- a/src/context.py
+++ b/src/context.py
@@ -78,7 +78,8 @@ def get_value():
     if compute_cluster_str:
         compute_cluster_dict = json.loads(compute_cluster_str)
         compute_cluster = ComputeClusterContext(
-            id=compute_cluster_dict.get("id", None), properties=compute_cluster_dict.get("properties", None)
+            id=compute_cluster_dict.get("id", None),
+            properties=compute_cluster_dict.get("properties", None),
         )
     else:
         compute_cluster = None

--- a/src/context.py
+++ b/src/context.py
@@ -22,6 +22,19 @@ class ComputeClusterContext:
     id: str
     properties: dict[str, typing.Any]
 
+    def __str__(self) -> str:
+        str_val = []
+
+        str_val.append(f"ID: {self.id}")
+        if self.properties:
+            str_val.append("Properties:")
+            for key, value in self.properties.items():
+                str_val.append(f"  {key}: {value}")
+        else:
+            str_val.append(f"Properties: {None}")
+
+        return "\n".join(str_val)
+
 
 @dataclasses.dataclass
 class CpuContext:
@@ -30,6 +43,21 @@ class CpuContext:
     quantity_vcpu: float
     architecture: str
     memory_gb: float
+
+    def __str__(self) -> str:
+        str_val = []
+
+        if self.quantity_vcpu is not None:
+            str_val.append(f"Quantity: {self.quantity_vcpu:.1f} vCPU")
+        else:
+            str_val.append("Quantity: N/A")
+        str_val.append(f"Architecture: {self.architecture or 'N/A'}")
+        if self.memory_gb is not None:
+            str_val.append(f"Memory: {self.memory_gb:.1f} GB")
+        else:
+            str_val.append("Memory: N/A")
+
+        return "\n".join(str_val)
 
 
 @dataclasses.dataclass
@@ -40,6 +68,15 @@ class GpuArchitectureContext:
     microarchitecture: str
     model: str
 
+    def __str__(self) -> str:
+        str_val = []
+
+        str_val.append(f"Vendor: {self.vendor}")
+        str_val.append(f"Microarchitecture: {self.microarchitecture}")
+        str_val.append(f"Model: {self.model}")
+
+        return "\n".join(str_val)
+
 
 @dataclasses.dataclass
 class GpuContext:
@@ -49,6 +86,25 @@ class GpuContext:
     architecture: GpuArchitectureContext
     memory_gb: float
 
+    def __str__(self) -> str:
+        str_val = []
+
+        if self.quantity_gpu is not None:
+            str_val.append(f"Quantity: {self.quantity_gpu:.1f} GPU")
+        else:
+            str_val.append("Quantity: None")
+        if self.architecture:
+            str_val.append("Architecture:")
+            str_val.append("  " + str(self.architecture).replace("\n", "\n  "))
+        else:
+            str_val.append(f"Architecture: {None}")
+        if self.memory_gb is not None:
+            str_val.append(f"Memory: {self.memory_gb:.1f} GB")
+        else:
+            str_val.append("Memory: None")
+
+        return "\n".join(str_val)
+
 
 @dataclasses.dataclass
 class HardwareContext:
@@ -56,6 +112,26 @@ class HardwareContext:
 
     cpu: CpuContext
     gpu: typing.Optional[GpuContext]
+
+    def __str__(self) -> str:
+        str_val = []
+
+        # CPU
+        if self.cpu:
+            str_val.append("Processing:")
+            str_val.append("  " + str(self.cpu).replace("\n", "\n  "))
+        else:
+            str_val.append("Processing: N/A")
+
+        # GPU
+        if self.gpu:
+            str_val.append("Accelerated processing:")
+            str_val.append("  " + str(self.gpu).replace("\n", "\n  "))
+
+        else:
+            str_val.append(f"Accelerated processing: {None}")
+
+        return "\n".join(str_val)
 
 
 @dataclasses.dataclass
@@ -69,6 +145,38 @@ class Context:
     hardware: HardwareContext
     env: str
     debug: bool
+
+    def __str__(self) -> str:
+        str_val = []
+
+        # bench id
+        str_val.append(f"Bench ID: {self.bench_id}")
+
+        # user and organization
+        str_val.append(f"User ID: {self.user_id}")
+        str_val.append(f"Organization ID: {self.org_id}")
+
+        # host compute cluster
+        if self.compute_cluster:
+            str_val.append("Compute cluster:")
+            str_val.append("  " + str(self.compute_cluster).replace("\n", "\n  "))
+        else:
+            str_val.append(f"Compute cluster: {None}")
+
+        # hardware
+        if self.hardware:
+            str_val.append("Hardware:")
+            str_val.append("  " + str(self.hardware).replace("\n", "\n  "))
+        else:
+            str_val.append(f"Hardware: {None}")
+
+        # environment
+        str_val.append(f"Environment: {self.env}")
+
+        # debug
+        str_val.append(f"Debug: {self.debug}")
+
+        return "\n".join(str_val)
 
 
 @functools.cache

--- a/src/context.py
+++ b/src/context.py
@@ -7,7 +7,7 @@ import typing
 __all__ = [
     "get_value",
     "Context",
-    "HostContext",
+    "ComputeClusterContext",
     "HardwareContext",
     "CpuContext",
     "GpuContext",
@@ -16,8 +16,8 @@ __all__ = [
 
 
 @dataclasses.dataclass
-class HostContext:
-    """Host for a Deep Origin ComputeBench"""
+class ComputeClusterContext:
+    """Host compute cluster for a Deep Origin ComputeBench"""
 
     id: str
     properties: dict[str, typing.Any]
@@ -65,7 +65,7 @@ class Context:
     bench_id: str
     user_id: str
     org_id: str
-    host: HostContext
+    compute_cluster: ComputeClusterContext
     hardware: HardwareContext
     env: str
     debug: bool
@@ -74,14 +74,14 @@ class Context:
 @functools.cache
 def get_value():
     """returns a context from environment variables"""
-    host_str = os.getenv("DEEP_ORIGIN_HOST", None)
-    if host_str:
-        host_dict = json.loads(host_str)
-        host = HostContext(
-            id=host_dict.get("id", None), properties=host_dict.get("properties", None)
+    compute_cluster_str = os.getenv("DEEP_ORIGIN_COMPUTE_CLUSTER", None)
+    if compute_cluster_str:
+        compute_cluster_dict = json.loads(compute_cluster_str)
+        compute_cluster = ComputeClusterContext(
+            id=compute_cluster_dict.get("id", None), properties=compute_cluster_dict.get("properties", None)
         )
     else:
-        host = None
+        compute_cluster = None
 
     hardware_str = os.getenv("DEEP_ORIGIN_HARDWARE", None)
     if hardware_str:
@@ -130,7 +130,7 @@ def get_value():
         bench_id=os.getenv("DEEP_ORIGIN_BENCH_ID", None),
         user_id=os.getenv("DEEP_ORIGIN_USER_ID", None),
         org_id=os.getenv("DEEP_ORIGIN_ORGANIZATION_ID", None),
-        host=host,
+        compute_cluster=compute_cluster,
         hardware=hardware,
         env=os.getenv("DEEP_ORIGIN_ENV", None),
         debug=os.getenv("DEEP_ORIGIN_DEBUG", "").lower() == "true",

--- a/src/context.py
+++ b/src/context.py
@@ -146,35 +146,52 @@ class Context:
     env: str
     debug: bool
 
-    def __str__(self) -> str:
+    def __str__(
+        self,
+        bench: bool = True,
+        compute_cluster: bool = False,
+        user: bool = True,
+        org: bool = True,
+        hardware: bool = False,
+        env: bool = True,
+        debug: bool = True,
+    ) -> str:
         str_val = []
 
         # bench id
-        str_val.append(f"Bench ID: {self.bench_id}")
-
-        # user and organization
-        str_val.append(f"User ID: {self.user_id}")
-        str_val.append(f"Organization ID: {self.org_id}")
+        if bench:
+            str_val.append(f"Bench ID: {self.bench_id}")
 
         # host compute cluster
-        if self.compute_cluster:
-            str_val.append("Compute cluster:")
-            str_val.append("  " + str(self.compute_cluster).replace("\n", "\n  "))
-        else:
-            str_val.append(f"Compute cluster: {None}")
+        if compute_cluster:
+            if self.compute_cluster:
+                str_val.append("Compute cluster:")
+                str_val.append("  " + str(self.compute_cluster).replace("\n", "\n  "))
+            else:
+                str_val.append(f"Compute cluster: {None}")
+
+        # user and organization
+        if user:
+            str_val.append(f"User ID: {self.user_id}")
+
+        if org:
+            str_val.append(f"Organization ID: {self.org_id}")
 
         # hardware
-        if self.hardware:
-            str_val.append("Hardware:")
-            str_val.append("  " + str(self.hardware).replace("\n", "\n  "))
-        else:
-            str_val.append(f"Hardware: {None}")
+        if hardware:
+            if self.hardware:
+                str_val.append("Hardware:")
+                str_val.append("  " + str(self.hardware).replace("\n", "\n  "))
+            else:
+                str_val.append(f"Hardware: {None}")
 
         # environment
-        str_val.append(f"Environment: {self.env}")
+        if env:
+            str_val.append(f"Environment: {self.env}")
 
         # debug
-        str_val.append(f"Debug: {self.debug}")
+        if debug:
+            str_val.append(f"Debug: {self.debug}")
 
         return "\n".join(str_val)
 

--- a/src/managed_data/_api.py
+++ b/src/managed_data/_api.py
@@ -156,7 +156,8 @@ def create_database(
 
 
     Returns:
-        A dictionary that conforms to a [CreateDatabaseResponse][src.managed_data.schema.CreateDatabaseResponse]."""
+        A dictionary that conforms to a [CreateDatabaseResponse][src.managed_data.schema.CreateDatabaseResponse].
+    """
 
     client = _get_default_client(client)
 

--- a/src/managed_data/schema.py
+++ b/src/managed_data/schema.py
@@ -158,7 +158,8 @@ class AddDatabaseColumnResponse(BaseModel):
 
 class DescribeRowResponse(BaseModel):
     """Schema for responses from the `DescribeRow` endpoint. This schema is complex because
-    the response schema depends on whether `DescribeRow` is called for a row or database."""
+    the response schema depends on whether `DescribeRow` is called for a row or database.
+    """
 
     id: str
     hid: str

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -81,23 +81,16 @@ class TestCase(unittest.TestCase):
         )
         self.assertEqual(expected_value, value)
 
-        stdout_capture = io.StringIO()
-        stderr_capture = io.StringIO()
-
-        with redirect_stdout(stdout_capture), redirect_stderr(stderr_capture):
-            with cli.App(argv=["context"]) as app:
-                app.run()
-            stdout = stdout_capture.getvalue().strip()
-        expected_stdout = "\n".join(
+        expected_str = "\n".join(
             [
                 "Bench ID: cute-bear-123",
-                "User ID: john-doe",
-                "Organization ID: acme-bio",
                 "Compute cluster:",
                 "  ID: us-west-2.aws.bench.deeporigin.io",
                 "  Properties:",
                 "    provider: aws",
-                "    region: us-west-2",
+                "    region: us-west-2",                
+                "User ID: john-doe",
+                "Organization ID: acme-bio",
                 "Hardware:",
                 "  Processing:",
                 "    Quantity: 8.0 vCPU",
@@ -114,7 +107,7 @@ class TestCase(unittest.TestCase):
                 "Debug: True",
             ]
         )
-        self.assertEqual(expected_stdout, stdout)
+        self.assertEqual(expected_str, value.__str__(compute_cluster=True, hardware=True))
 
     def test_get_project_paths_nested_null(self):
         context.get_value.cache_clear()
@@ -167,23 +160,14 @@ class TestCase(unittest.TestCase):
         )
         self.assertEqual(expected_value, value)
 
-        stdout_capture = io.StringIO()
-        stderr_capture = io.StringIO()
-
-        with redirect_stdout(stdout_capture), redirect_stderr(stderr_capture):
-            with cli.App(argv=["context"]) as app:
-                app.run()
-
-            stdout = stdout_capture.getvalue().strip()
-
-        expected_stdout = "\n".join(
+        expected_str = "\n".join(
             [
                 "Bench ID: None",
-                "User ID: None",
-                "Organization ID: None",
                 "Compute cluster:",
                 "  ID: None",
-                "  Properties: None",
+                "  Properties: None",                
+                "User ID: None",
+                "Organization ID: None",
                 "Hardware:",
                 "  Processing:",
                 "    Quantity: N/A",
@@ -197,7 +181,7 @@ class TestCase(unittest.TestCase):
                 "Debug: False",
             ]
         )
-        self.assertEqual(expected_stdout, stdout)
+        self.assertEqual(expected_str, value.__str__(compute_cluster=True, hardware=True))
 
     def test_get_project_paths_null_1(self):
         context.get_value.cache_clear()
@@ -225,20 +209,12 @@ class TestCase(unittest.TestCase):
         )
         self.assertEqual(expected_value, value)
 
-        stdout_capture = io.StringIO()
-        stderr_capture = io.StringIO()
-
-        with redirect_stdout(stdout_capture), redirect_stderr(stderr_capture):
-            with cli.App(argv=["context"]) as app:
-                app.run()
-
-            stdout = stdout_capture.getvalue().strip()
-        expected_stdout = "\n".join(
+        expected_str = "\n".join(
             [
                 "Bench ID: None",
+                "Compute cluster: None",                
                 "User ID: None",
                 "Organization ID: None",
-                "Compute cluster: None",
                 "Hardware:",
                 "  Processing: N/A",
                 "  Accelerated processing: None",
@@ -246,7 +222,7 @@ class TestCase(unittest.TestCase):
                 "Debug: False",
             ]
         )
-        self.assertEqual(expected_stdout, stdout)
+        self.assertEqual(expected_str, value.__str__(compute_cluster=True, hardware=True))
 
     def test_get_project_paths_null_2(self):
         context.get_value.cache_clear()
@@ -264,6 +240,30 @@ class TestCase(unittest.TestCase):
         )
         self.assertEqual(expected_value, value)
 
+        expected_str_with_cluster_hardware = "\n".join(
+            [
+                "Bench ID: None",
+                "Compute cluster: None",
+                "User ID: None",
+                "Organization ID: None",                
+                "Hardware: None",
+                "Environment: None",
+                "Debug: False",
+            ]
+        )
+        self.assertEqual(expected_str_with_cluster_hardware, value.__str__(compute_cluster=True, hardware=True))
+
+        expected_str_without_cluster_hardware = "\n".join(
+            [
+                "Bench ID: None",
+                "User ID: None",
+                "Organization ID: None",                
+                "Environment: None",
+                "Debug: False",
+            ]
+        )
+        self.assertEqual(expected_str_without_cluster_hardware, value.__str__(compute_cluster=False, hardware=False))
+
         stdout_capture = io.StringIO()
         stderr_capture = io.StringIO()
 
@@ -273,15 +273,5 @@ class TestCase(unittest.TestCase):
 
             stdout = stdout_capture.getvalue().strip()
 
-        expected_stdout = "\n".join(
-            [
-                "Bench ID: None",
-                "User ID: None",
-                "Organization ID: None",
-                "Compute cluster: None",
-                "Hardware: None",
-                "Environment: None",
-                "Debug: False",
-            ]
-        )
+        expected_stdout = expected_str_without_cluster_hardware
         self.assertEqual(expected_stdout, stdout)

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -20,10 +20,11 @@ class TestCase(unittest.TestCase):
             "DEEP_ORIGIN_BENCH_ID": "cute-bear-123",
             "DEEP_ORIGIN_USER_ID": "john-doe",
             "DEEP_ORIGIN_ORGANIZATION_ID": "acme-bio",
-            "DEEP_ORIGIN_HOST": json.dumps(
+            "DEEP_ORIGIN_COMPUTE_CLUSTER": json.dumps(
                 {
-                    "id": "aws",
+                    "id": "us-west-2.aws.bench.deeporigin.io",
                     "properties": {
+                        "provider": "aws",
                         "region": "us-west-2",
                     },
                 }
@@ -55,9 +56,9 @@ class TestCase(unittest.TestCase):
             bench_id="cute-bear-123",
             user_id="john-doe",
             org_id="acme-bio",
-            host=context.HostContext(
-                id="aws",
-                properties={"region": "us-west-2"},
+            compute_cluster=context.ComputeClusterContext(
+                id="us-west-2.aws.bench.deeporigin.io",
+                properties={"provider": "aws", "region": "us-west-2"},
             ),
             hardware=context.HardwareContext(
                 cpu=context.CpuContext(
@@ -92,9 +93,10 @@ class TestCase(unittest.TestCase):
                 "Bench ID: cute-bear-123",
                 "User ID: john-doe",
                 "Organization ID: acme-bio",
-                "Host:",
-                "  ID: aws",
+                "Compute cluster:",
+                "  ID: us-west-2.aws.bench.deeporigin.io",
                 "  Properties:",
+                "    provider: aws",
                 "    region: us-west-2",
                 "Hardware:",
                 "  Processing:",
@@ -117,7 +119,7 @@ class TestCase(unittest.TestCase):
     def test_get_project_paths_nested_null(self):
         context.get_value.cache_clear()
         env = {
-            "DEEP_ORIGIN_HOST": json.dumps(
+            "DEEP_ORIGIN_COMPUTE_CLUSTER": json.dumps(
                 {
                     "id": None,
                     "properties": None,
@@ -144,7 +146,7 @@ class TestCase(unittest.TestCase):
             bench_id=None,
             user_id=None,
             org_id=None,
-            host=context.HostContext(
+            compute_cluster=context.ComputeClusterContext(
                 id=None,
                 properties=None,
             ),
@@ -179,7 +181,7 @@ class TestCase(unittest.TestCase):
                 "Bench ID: None",
                 "User ID: None",
                 "Organization ID: None",
-                "Host:",
+                "Compute cluster:",
                 "  ID: None",
                 "  Properties: None",
                 "Hardware:",
@@ -213,7 +215,7 @@ class TestCase(unittest.TestCase):
             bench_id=None,
             user_id=None,
             org_id=None,
-            host=None,
+            compute_cluster=None,
             hardware=context.HardwareContext(
                 cpu=None,
                 gpu=None,
@@ -236,7 +238,7 @@ class TestCase(unittest.TestCase):
                 "Bench ID: None",
                 "User ID: None",
                 "Organization ID: None",
-                "Host: None",
+                "Compute cluster: None",
                 "Hardware:",
                 "  Processing: N/A",
                 "  Accelerated processing: None",
@@ -255,7 +257,7 @@ class TestCase(unittest.TestCase):
             bench_id=None,
             user_id=None,
             org_id=None,
-            host=None,
+            compute_cluster=None,
             hardware=None,
             env=None,
             debug=False,
@@ -276,7 +278,7 @@ class TestCase(unittest.TestCase):
                 "Bench ID: None",
                 "User ID: None",
                 "Organization ID: None",
-                "Host: None",
+                "Compute cluster: None",
                 "Hardware: None",
                 "Environment: None",
                 "Debug: False",

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -88,7 +88,7 @@ class TestCase(unittest.TestCase):
                 "  ID: us-west-2.aws.bench.deeporigin.io",
                 "  Properties:",
                 "    provider: aws",
-                "    region: us-west-2",                
+                "    region: us-west-2",
                 "User ID: john-doe",
                 "Organization ID: acme-bio",
                 "Hardware:",
@@ -107,7 +107,9 @@ class TestCase(unittest.TestCase):
                 "Debug: True",
             ]
         )
-        self.assertEqual(expected_str, value.__str__(compute_cluster=True, hardware=True))
+        self.assertEqual(
+            expected_str, value.__str__(compute_cluster=True, hardware=True)
+        )
 
     def test_get_project_paths_nested_null(self):
         context.get_value.cache_clear()
@@ -165,7 +167,7 @@ class TestCase(unittest.TestCase):
                 "Bench ID: None",
                 "Compute cluster:",
                 "  ID: None",
-                "  Properties: None",                
+                "  Properties: None",
                 "User ID: None",
                 "Organization ID: None",
                 "Hardware:",
@@ -181,7 +183,9 @@ class TestCase(unittest.TestCase):
                 "Debug: False",
             ]
         )
-        self.assertEqual(expected_str, value.__str__(compute_cluster=True, hardware=True))
+        self.assertEqual(
+            expected_str, value.__str__(compute_cluster=True, hardware=True)
+        )
 
     def test_get_project_paths_null_1(self):
         context.get_value.cache_clear()
@@ -212,7 +216,7 @@ class TestCase(unittest.TestCase):
         expected_str = "\n".join(
             [
                 "Bench ID: None",
-                "Compute cluster: None",                
+                "Compute cluster: None",
                 "User ID: None",
                 "Organization ID: None",
                 "Hardware:",
@@ -222,7 +226,9 @@ class TestCase(unittest.TestCase):
                 "Debug: False",
             ]
         )
-        self.assertEqual(expected_str, value.__str__(compute_cluster=True, hardware=True))
+        self.assertEqual(
+            expected_str, value.__str__(compute_cluster=True, hardware=True)
+        )
 
     def test_get_project_paths_null_2(self):
         context.get_value.cache_clear()
@@ -245,24 +251,30 @@ class TestCase(unittest.TestCase):
                 "Bench ID: None",
                 "Compute cluster: None",
                 "User ID: None",
-                "Organization ID: None",                
+                "Organization ID: None",
                 "Hardware: None",
                 "Environment: None",
                 "Debug: False",
             ]
         )
-        self.assertEqual(expected_str_with_cluster_hardware, value.__str__(compute_cluster=True, hardware=True))
+        self.assertEqual(
+            expected_str_with_cluster_hardware,
+            value.__str__(compute_cluster=True, hardware=True),
+        )
 
         expected_str_without_cluster_hardware = "\n".join(
             [
                 "Bench ID: None",
                 "User ID: None",
-                "Organization ID: None",                
+                "Organization ID: None",
                 "Environment: None",
                 "Debug: False",
             ]
         )
-        self.assertEqual(expected_str_without_cluster_hardware, value.__str__(compute_cluster=False, hardware=False))
+        self.assertEqual(
+            expected_str_without_cluster_hardware,
+            value.__str__(compute_cluster=False, hardware=False),
+        )
 
         stdout_capture = io.StringIO()
         stderr_capture = io.StringIO()


### PR DESCRIPTION
`deeporigin context` is intended to print out information including
- The compute cluster where the bench is being run. This is to help developers, such as molecular modeling, communicate with other containers.
- Hardware. This is to provide users, such as molecular modeling, accurate information about the resources of the bench. This is important because the Linux commands for reporting memory don't work as expected in containers in shared hosts.

This PR disables printing this information because the platform no longer provides this information. [DOS-3008](https://deeporiginbio.atlassian.net/browse/DOS-3008) will add it. Until that point, we should avoid printing unsupported information.

Rather than deleting support for this information in this library, I instead refactored the library to make the printing of this information conditional. Once the platform resumes providing this information, we can simply change the default values of these conditions.

The second commit of this PR also formats a couple of source files.

The third commit of this PR refactors the generation of the string representation of context from the CLI module to `__str__` methods for the classes which capture context information. This was done to make it easier to pass conditional information for testing.

Closes [DOS-3009](https://deeporiginbio.atlassian.net/browse/DOS-3009)
