### PR TITLE
feat: better way of interacting with databases

### DIFF
--- a/src/data_hub/api.py
+++ b/src/data_hub/api.py
@@ -505,7 +505,7 @@ def set_data_in_cells(
     column = [
         col
         for col in response.cols
-        if col["id"] == column_id or col["name"] == column_id or col["key"] == column_id
+        if col["id"] == column_id or col["name"] == column_id
     ]
 
     if len(column) != 1:
@@ -568,7 +568,7 @@ def set_cell_data(
     column = [
         col
         for col in response.cols
-        if col["id"] == column_id or col["name"] == column_id or col["key"] == column_id
+        if col["id"] == column_id or col["name"] == column_id
     ]
 
     if len(column) != 1:
@@ -867,9 +867,9 @@ def get_dataframe(
 
         # this import is here because we don't want to
         # import pandas unless we actually use this function
-        import pandas as pd
+        from deeporigin.data_hub.dataframe import DataFrame
 
-        df = pd.DataFrame(data)
+        df = DataFrame(data)
         df.attrs["file_ids"] = list(set(file_ids))
         df.attrs["reference_ids"] = list(set(reference_ids))
         df.attrs["id"] = database_id
@@ -1170,10 +1170,7 @@ def get_row_data(
     column_name_mapper = dict()
     column_cardinality_mapper = dict()
     for col in parent_response.cols:
-        if use_column_keys:
-            column_name_mapper[col["id"]] = col["key"]
-        else:
-            column_name_mapper[col["id"]] = col["name"]
+        column_name_mapper[col["id"]] = col["name"]
         column_cardinality_mapper[col["id"]] = col["cardinality"]
 
     # now use this to construct the required dictionary
@@ -1182,10 +1179,7 @@ def get_row_data(
     for col in parent_response.cols:
         if "systemType" in col.keys() and col["systemType"] == "bodyDocument":
             continue
-        if use_column_keys:
-            row_data[col["key"]] = None
-        else:
-            row_data[col["name"]] = None
+        row_data[col["name"]] = None
     if not hasattr(response, "fields"):
         return row_data
     for field in response.fields:

--- a/src/data_hub/dataframe.py
+++ b/src/data_hub/dataframe.py
@@ -1,0 +1,36 @@
+from typing import Optional
+
+import pandas as pd
+from deeporigin.data_hub import api
+
+
+class DataFrame(pd.DataFrame):
+    def _repr_html_(self):
+        header = "<h3>Deep Origin DataFrame</h3>"
+        df_html = super()._repr_html_()
+        return header + df_html
+
+    def __repr__(self):
+        header = "Deep Origin DataFrame\n"
+        df_representation = super().__repr__()
+        return header + df_representation
+
+    def sync(self, *, columns: Optional[list] = None):
+        print("Syncing...")
+
+        for column in self.columns:
+            if column == "Validation Status":
+                continue
+
+            print(column)
+
+            api.set_data_in_cells(
+                values=self[column],
+                row_ids=list(self.index),
+                column_id=column,
+                database_id=self.attrs["id"],
+            )
+
+    @property
+    def _constructor(self):
+        return DataFrame


### PR DESCRIPTION
## problem description

a typical user flow is 

- get some data from a database. data is then exstant as a pandas dataframe
- do some computation on it
- maybe write results to a new column in the dataframe
- write those results back to the DO database (sync back)

right now, to do so, we have to worry about API calls where we have to laboriously pass database ID, column IDs, etc. 

## proposed solution

### user experience

```python
df = api.get_dataframe("foo")

# do some compute on it
df.sync()
```

### technical implementation 

we create a new class that subclasses a pandas dataframe, and write special methods to talk to the data hub


## changes

- [ ] api.get_dataframe() stores database info in dataframe attrs
- [ ] dataframe contains information about columns 
- [ ] dataframe.sync works 