### PR TITLE
fix: more bugfixes & improvements

### DIFF
--- a/docs/data-hub/dataframes.md
+++ b/docs/data-hub/dataframes.md
@@ -65,6 +65,7 @@ In either case, when we view the DataFrame once more using `df`, we see the upda
 
 ![DataFrame with warning telling us about local changes that have not been written back to Deep Origin](../images/dataframe-1.png)
 
+
 ## Write data back to Deep Origin
 
 !!! warning "Work in progress"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "deeporigin-data-sdk==0.1.0a11",
     "humanize",
     "packaging",
+    "diskcache",
 ]
 dynamic = ["version"]
 

--- a/src/data_hub/api.py
+++ b/src/data_hub/api.py
@@ -902,11 +902,11 @@ def get_dataframe(
     reference_ids = []
     file_ids = []
 
-    # remove notebook columns because they are not
-    # shown in the UI as columns
     if columns is None:
         return None
 
+    # remove notebook columns because they are not
+    # shown in the UI as columns
     columns = [
         col
         for col in columns

--- a/src/data_hub/dataframe.py
+++ b/src/data_hub/dataframe.py
@@ -165,12 +165,13 @@ class DataFrame(pd.DataFrame):
     def __repr__(self):
         """method override to customize printing in an interactive session"""
 
+        df_representation = super().__repr__()
         try:
             header = f'{self.attrs["metadata"]["hid"]}\n'
-            df_representation = super().__repr__()
-            return header + df_representation
         except Exception:
-            return super().__repr__()
+            header = ""
+
+        return header + df_representation
 
     @classmethod
     def from_deeporigin(

--- a/src/data_hub/dataframe.py
+++ b/src/data_hub/dataframe.py
@@ -231,19 +231,23 @@ class DataFrame(pd.DataFrame):
 
             if len(column_metadata) == 0:
                 # infer column type
+                column_type = _infer_column_type(self[column])
 
                 # make a new column
-                api.add_database_column(
+                response = api.add_database_column(
                     database_id=self.attrs["metadata"]["hid"],
-                    type="integer",
+                    type=column_type,
                     name=column,
                     key=column,
                 )
 
-            column_metadata = column_metadata[0]
+                # add column metadata to column
+                self.attrs["metadata"]["cols"].append(response["data"]["column"])
+            else:
+                column_metadata = column_metadata[0]
 
-            if column_metadata["type"] == "file":
-                continue
+                if column_metadata["type"] == "file":
+                    continue
 
             if rows is None:
                 # we're updating a whole column
@@ -316,5 +320,5 @@ def _infer_column_type(column: pd.Series):
         if result:
             return dtype
 
-    # If no clear type is found, return "mixed"
-    return "mixed"
+    # no clear type, fall back to string
+    return "string"

--- a/src/data_hub/dataframe.py
+++ b/src/data_hub/dataframe.py
@@ -137,7 +137,7 @@ class DataFrame(pd.DataFrame):
             )
             edited_time_ago = humanize.naturaltime(now - date_obj)
 
-            header = f'<h4 style="color: #363636;">Deep Origin / {org_name} / <a href = "{url}">{name} </a></h4>'
+            header = f'<h4 style="color: #808080;">Deep Origin / {org_name} / <a href = "{url}">{name} </a></h4>'
             txt = f'<p style="font-size: 12px; color: #808080;">Created {created_time_ago}. Row {self.attrs["last_updated_row"].hid} was last edited {edited_time_ago}'
             try:
                 last_edited_by = get_last_edited_user_name(

--- a/src/data_hub/dataframe.py
+++ b/src/data_hub/dataframe.py
@@ -263,6 +263,12 @@ class DataFrame(pd.DataFrame):
             print(f"✔︎ Wrote {len(rows)} rows in {column} to Deep Origin database.")
             self._modified_columns.discard(column)
 
+        # fetch info for the last modified row so we can update what we show
+        try:
+            self.attrs["last_updated_row"] = api.describe_row(row_id=rows[-1])
+        except Exception:
+            pass
+
     @property
     def _constructor(self):
         """this method overrides the _constructor property to return a DataFrame and is required for compatibility with a pandas DataFrame"""

--- a/src/data_hub/dataframe.py
+++ b/src/data_hub/dataframe.py
@@ -81,6 +81,20 @@ class DataFrame(pd.DataFrame):
         else:
             self._modified_columns.add(key)
 
+    def head(self, n=5):
+        """Override the `head` method so that we don't display a spurious modified warning"""
+
+        df = super().head(n)
+        df._modified_columns = None
+        return df
+
+    def tail(self, n=5):
+        """Override the `tail` method so that we don't display a spurious modified warning"""
+
+        df = super().tail(n)
+        df._modified_columns = None
+        return df
+
     def _repr_html_(self):
         """method override to customize printing in a Jupyter notebook"""
 

--- a/src/platform/api.py
+++ b/src/platform/api.py
@@ -1,6 +1,10 @@
 """module to interact with the platform API"""
 
+import os
+
+import diskcache as dc
 import requests
+from beartype import beartype
 from deeporigin import auth
 from deeporigin.config import get_value
 
@@ -34,12 +38,22 @@ def resolve_user(user_id: str):
     return response.json()
 
 
-def get_user_name(user_id: str):
-    """get user name from user DRN"""
+@beartype
+def get_user_name(user_id: str) -> str:
+    """get user name from user ID"""
+
+    CACHE_PATH = os.path.expanduser("~/.deeporigin/user_ids")
+
+    cache = dc.Cache(CACHE_PATH)
+
+    if cache.get(user_id) is not None:
+        return cache.get(user_id)
 
     response = resolve_user(user_id)
 
-    return response["data"]["attributes"]["name"]
+    name = response["data"]["attributes"]["name"]
+    cache.set(user_id, name)
+    return name
 
 
 def get_last_edited_user_name(row):

--- a/src/platform/api.py
+++ b/src/platform/api.py
@@ -38,13 +38,16 @@ def _make_request(endpoint: str) -> dict:
     return response.json()
 
 
+@beartype
+def _get_org_id() -> str:
+    value = get_value()
+    return value["organization_id"]
+
+
 def resolve_user(user_id: str):
     """get details about a user in the platform"""
 
-    value = get_value()
-    org_id = value["organization_id"]
-
-    endpoint = f"/organizations/{org_id}/users/{user_id}"
+    endpoint = f"/organizations/{_get_org_id()}/users/{user_id}"
 
     return _make_request(endpoint)
 
@@ -53,6 +56,11 @@ def whoami():
     """get details about currently signed in user"""
 
     return _make_request("/users/me")
+
+
+def get_workstations():
+    """get information about all workstations in the organization"""
+    return _make_request(f"/computebenches/{_get_org_id()}")
 
 
 @beartype

--- a/src/platform/api.py
+++ b/src/platform/api.py
@@ -9,14 +9,14 @@ from deeporigin import auth
 from deeporigin.config import get_value
 
 
-def resolve_user(user_id: str):
-    """get details about a user in the platform"""
+def _make_request(endpoint: str) -> dict:
+    """make a request to the platform API"""
+
+    if not endpoint.startswith("/"):
+        endpoint = "/" + endpoint
 
     tokens = auth.get_tokens(refresh=False)
     access_token = tokens["access"]
-
-    value = get_value()
-    org_id = value["organization_id"]
 
     headers = {
         "accept": "application/json",
@@ -26,9 +26,9 @@ def resolve_user(user_id: str):
 
     env = get_value()["env"]
     if env == "prod":
-        url = f"https://os.deeporigin.io/api/organizations/{org_id}/users/{user_id}"
+        url = f"https://os.deeporigin.io/api/{endpoint}"
     else:
-        f"https://{env}.deeporigin.io/api/organizations/{org_id}/users/{user_id}"
+        f"https://{env}.deeporigin.io/api/{endpoint}"
 
     response = requests.get(
         url,
@@ -36,6 +36,23 @@ def resolve_user(user_id: str):
     )
 
     return response.json()
+
+
+def resolve_user(user_id: str):
+    """get details about a user in the platform"""
+
+    value = get_value()
+    org_id = value["organization_id"]
+
+    endpoint = f"/organizations/{org_id}/users/{user_id}"
+
+    return _make_request(endpoint)
+
+
+def whoami():
+    """get details about currently signed in user"""
+
+    return _make_request("/users/me")
 
 
 @beartype

--- a/src/platform/api.py
+++ b/src/platform/api.py
@@ -26,9 +26,9 @@ def _make_request(endpoint: str) -> dict:
 
     env = get_value()["env"]
     if env == "prod":
-        url = f"https://os.deeporigin.io/api/{endpoint}"
+        url = f"https://os.deeporigin.io/api{endpoint}"
     else:
-        f"https://{env}.deeporigin.io/api/{endpoint}"
+        f"https://{env}.deeporigin.io/api{endpoint}"
 
     response = requests.get(
         url,


### PR DESCRIPTION
## changes

- [x] wrapped all pretty printing code for data frames in a try so that this never breaks important code 
- [x] overrides for head and tail methods
- [x] better visibility in dark mode for dataframe headers
- [ ] ability to retrieve notebook entries 
- [x] ability to add a new column in a dataframe
- [x] caching of user names for faster displays

## technical discussion 

previously this behavior existed, where printing a dataframe worked, but using df.head() would trigger a spurious warning about dataframes containing modified data

<img width="758" alt="dataframe-warnings 9 07 43 AM" src="https://github.com/user-attachments/assets/64b29de3-cca5-4b28-a92c-78d5d70eb1cc">

this was because this was technically correct -- pandas df.head() created a shallow copy of a dataframe, which was technically a new object, and because the data in the new dataframe was not the same, the warning was shown.

however, this is useless and misleading from an end user persp. so we override these methods. 