### PR TITLE
fix: fixed a bug where expired tokens were not being refreshed

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Check docstrings using interrogate
         run: |
-          pip install interrogate
+          pip install interrogate --break-system-packages
           if [ $(interrogate -c pyproject.toml -v . -f 100 | grep "FAILED" | wc -l) = 1 ]; then
              echo "necessary docstrings missing:"
              interrogate -vv . -f 100 

--- a/src/data_hub/_api.py
+++ b/src/data_hub/_api.py
@@ -144,8 +144,19 @@ def _create_function(method_path):
                 print("⚠️ Token expired. Refreshing credentials...")
                 tokens = auth.read_cached_tokens()
                 tokens["access"] = auth.refresh_tokens(tokens["refresh"])
+
+                # cache to disk
                 auth.cache_tokens(tokens)
+
+                # clear the cache from memory
+                # so that we force the client to read the new
+                # token from disk
+                auth.get_tokens.cache_clear()
+
+                # configure the client to use the new access
+                # token
                 client.token = tokens["access"]
+
                 method = _get_method(client, method_path)
                 response = method(**kwargs)
             else:


### PR DESCRIPTION
## problem description 

expired tokens were correctly being intercepted and a new token was being obtained, but the functools.cache decorator on one of the functions was preventing us from reading the new token on disk, and instead relying on a cached token (cached in memory).

this led to a bug where the warning about expired tokens never went away (unless you reloaded and reimported)