### PR TITLE
fix: suppress message about new version on lambda

### DIFF
--- a/src/data_hub/api.py
+++ b/src/data_hub/api.py
@@ -9,7 +9,6 @@ from urllib.parse import urlparse, urlunparse
 
 import httpx
 from beartype import beartype
-from deeporigin import __version__
 
 # this import is to allow us to use functions
 # not marked in __all__ in _api
@@ -29,22 +28,14 @@ from deeporigin.utils.constants import (
 )
 from deeporigin.utils.core import find_last_updated_row, sha256_checksum
 from deeporigin.utils.network import (
-    _get_pypi_version,
     _parse_params_from_url,
+    check_for_updates,
     download_sync,
 )
 from deeporigin.utils.types import ListFilesResponse
-from packaging.version import Version
 from tqdm import tqdm
 
-try:
-    latest_pypi_version = Version(_get_pypi_version())
-    if Version(__version__) < latest_pypi_version:
-        print(
-            f"🎈 A new version of Deep Origin is available. You have version {__version__}. The latest version is {latest_pypi_version}. Please update to the newest version."
-        )
-except Exception:
-    pass
+check_for_updates()
 
 
 def ensure_client(func):

--- a/src/data_hub/dataframe.py
+++ b/src/data_hub/dataframe.py
@@ -18,6 +18,9 @@ from deeporigin.utils.constants import (
     DatabaseReturnType,
     IDFormat,
 )
+from deeporigin.utils.network import check_for_updates
+
+check_for_updates()
 
 
 class DataFrame(pd.DataFrame):

--- a/src/platform/api.py
+++ b/src/platform/api.py
@@ -12,8 +12,10 @@ from deeporigin import auth
 from deeporigin.config import get_value
 from deeporigin.exceptions import DeepOriginException
 from deeporigin.utils.core import _ensure_do_folder
-from deeporigin.utils.network import _get_domain_name
+from deeporigin.utils.network import _get_domain_name, check_for_updates
 from jwt.algorithms import RSAAlgorithm
+
+check_for_updates()
 
 
 def _make_get_request(endpoint: str) -> dict:

--- a/src/utils/network.py
+++ b/src/utils/network.py
@@ -1,14 +1,32 @@
 """this module contains network related utility functions"""
 
+import functools
 import json
 from pathlib import Path
 from urllib.parse import parse_qs, urljoin, urlparse
 
 import requests
 from beartype import beartype
+from deeporigin import __version__
 from deeporigin.exceptions import DeepOriginException
 from deeporigin.utils.config import _get_domain_name
-from deeporigin.utils.core import _ensure_do_folder
+from deeporigin.utils.core import _ensure_do_folder, in_aws_lambda
+from packaging.version import Version
+
+
+@functools.cache
+def check_for_updates():
+    """check if a new version is available. If so, print an message"""
+    if not in_aws_lambda():
+        try:
+            latest_pypi_version = Version(_get_pypi_version())
+            if Version(__version__) < latest_pypi_version:
+                print(
+                    f"🎈 A new version of Deep Origin is available. You have version {__version__}. The latest version is {latest_pypi_version}. Please update to the newest version."
+                )
+
+        except Exception:
+            pass
 
 
 @beartype


### PR DESCRIPTION
## changes

previously, using the AI assistant would surface this message, which cannot be acted upon because the user can't upgrade the client


<img width="799" alt="Screenshot 2024-10-15 at 11 56 06 AM" src="https://github.com/user-attachments/assets/5ee1fa25-8b1f-4b61-9863-1c59343867bd">


