### PR TITLE
feat: slicing a dataframe using `loc` preserves attributes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,7 @@ endif
 	interrogate -c pyproject.toml -v . -f 100 && \
 	python3 -m coverage run -m pytest -x -n $(n_workers) --failed-first -k $(chosen_tests) --client $(client) && \
 	python3 -m coverage html && \
-	deactivate && \
-	open htmlcov/index.html; \
+	deactivate
 
 # set up jupyter dev kernel
 jupyter:

--- a/src/data_hub/dataframe.py
+++ b/src/data_hub/dataframe.py
@@ -31,6 +31,24 @@ class DataFrame(pd.DataFrame):
     _modified_columns: dict = dict()
     """if data is modified in a dataframe, and auto_sync is False, this list will contain the columns that have been modified so that the Deep Origin database can be updated. If an empty list, the Deep Origin database will not be updated, and the dataframe matches the Deep Origin database at the time of creation."""
 
+    @property
+    def loc(self):
+        class _LocIndexer:
+            def __init__(self, df):
+                self.df = df
+
+            def __getitem__(self, key):
+                # first call the superclass method
+                df = super(DataFrame, self.df).loc[key]
+
+                # inherit attributes
+                df.attrs = self.df.attrs
+
+                return df
+
+        # Return the custom _LocIndexer instance
+        return _LocIndexer(self)
+
     class AtIndexer:
         """this class override is used to intercept calls to at indexer of a pandas dataframe"""
 

--- a/src/data_hub/dataframe.py
+++ b/src/data_hub/dataframe.py
@@ -58,6 +58,8 @@ class DataFrame(pd.DataFrame):
                 return df
 
             def __setitem__(self, key, value):
+                """callback for adding a new row, typically"""
+
                 if not self.df._allow_adding_rows:
                     # adding rows is not allowed
                     if isinstance(key, (list, pd.Index)):
@@ -66,6 +68,8 @@ class DataFrame(pd.DataFrame):
                     elif key not in self.df.index:
                         raise ValueError(__NO_NEW_ROWS_MSG__)
                 super(DataFrame, self.df).loc[key] = value
+
+                # TODO we need to mark that every column has been modified, but only this row
 
         # Return the custom _LocIndexer instance
         return _LocIndexer(self)

--- a/src/data_hub/dataframe.py
+++ b/src/data_hub/dataframe.py
@@ -19,6 +19,9 @@ from deeporigin.utils.network import check_for_updates
 check_for_updates()
 
 
+__NO_NEW_ROWS_MSG__ = "Adding rows is not allowed, because this dataframe corresponds to a subset of the rows in the corresponding database."
+
+
 class DataFrame(pd.DataFrame):
     """A subclass of pandas DataFrame that allows for easy updating of a Deep Origin database. This can be used as a drop-in replacement for a pandas DataFrame, and should support all methods a pandas DataFrame supports.
 
@@ -30,6 +33,9 @@ class DataFrame(pd.DataFrame):
 
     _modified_columns: dict = dict()
     """if data is modified in a dataframe, and auto_sync is False, this list will contain the columns that have been modified so that the Deep Origin database can be updated. If an empty list, the Deep Origin database will not be updated, and the dataframe matches the Deep Origin database at the time of creation."""
+
+    _allow_adding_rows: bool = True
+    """If `True`, new rows can be added to the dataframe. If `False`, new rows cannot be added to the dataframe."""
 
     @property
     def loc(self):
@@ -44,7 +50,22 @@ class DataFrame(pd.DataFrame):
                 # inherit attributes
                 df.attrs = self.df.attrs
 
+                # disallow adding rows
+                df._allow_adding_rows = False
+
+                df._modified_columns = self.df._modified_columns
+
                 return df
+
+            def __setitem__(self, key, value):
+                if not self.df._allow_adding_rows:
+                    # adding rows is not allowed
+                    if isinstance(key, (list, pd.Index)):
+                        if not all(k in self.df.index for k in key):
+                            raise ValueError(__NO_NEW_ROWS_MSG__)
+                    elif key not in self.df.index:
+                        raise ValueError(__NO_NEW_ROWS_MSG__)
+                super(DataFrame, self.df).loc[key] = value
 
         # Return the custom _LocIndexer instance
         return _LocIndexer(self)
@@ -61,7 +82,14 @@ class DataFrame(pd.DataFrame):
             return self.obj._get_value(*key)
 
         def __setitem__(self, key, value) -> None:
-            """intercept for the set operation""" ""
+            """intercept for the set operation"""
+
+            if (
+                isinstance(value, pd.Series)
+                and len(value) > len(self)
+                and not self._allow_adding_rows
+            ):
+                raise ValueError(__NO_NEW_ROWS_MSG__)
 
             old_value = self.obj._get_value(*key)
             if value == old_value:
@@ -122,6 +150,19 @@ class DataFrame(pd.DataFrame):
         df = super().tail(n)
         df._modified_columns = None
         return df
+
+    def append(
+        self,
+        other,
+        ignore_index=False,
+        verify_integrity=False,
+        sort=False,
+    ):
+        """Override the `append` method"""
+        if self._allow_adding_rows:
+            return super().append(other, ignore_index, verify_integrity, sort)
+        else:
+            raise ValueError(__NO_NEW_ROWS_MSG__)
 
     def _repr_html_(self):
         """method override to customize printing in a Jupyter notebook"""

--- a/tests/test_dataframe.py
+++ b/tests/test_dataframe.py
@@ -30,12 +30,14 @@ def config(pytestconfig):
         data["mock"] = True
 
         # Create the DataFrame
-        data["df"] = pd.DataFrame(
-            {
-                "integer": np.random.randint(1, 100, size=10),
-                "float": np.random.random(10),
-            },
-            index=[f"x-{i}" for i in range(1, 11)],
+        data["df"] = DataFrame(
+            pd.DataFrame(
+                {
+                    "integer": np.random.randint(1, 100, size=10),
+                    "float": np.random.random(10),
+                },
+                index=[f"x-{i}" for i in range(1, 11)],
+            )
         )
 
     else:

--- a/tests/test_dataframe.py
+++ b/tests/test_dataframe.py
@@ -1,23 +1,43 @@
 """this module contains tests for the DataFrame class"""
 
+import uuid
+
 import numpy as np
+import pandas as pd
 import pytest
 from deeporigin.data_hub import api
 from deeporigin.data_hub.dataframe import DataFrame
 
-from tests.utils import clean_up_test_objects, minimal_config
+from tests.utils import clean_up_test_objects
 
-TEST_PREFIX = "tc-x1zrncgf6F-"
-TEST_DB_NAME = TEST_PREFIX + "db"
+TEST_PREFIX = "tc-"
+
 COLUMNS = ["float", "integer"]
 
+SKIP_MSG = "Skipping this test because we can't test this well using a mocked client"
 
-@pytest.fixture(scope="session", autouse=True)
+
+@pytest.fixture(scope="function", autouse=True)
 def config(pytestconfig):
     """this config block sets up a database that we can operate on in the tests"""
+
+    salt = str(uuid.uuid4())[:8]
+
+    TEST_DB_NAME = TEST_PREFIX + salt + "-db"
+
     data = dict()
     if pytestconfig.getoption("client") == "mock":
         data["mock"] = True
+
+        # Create the DataFrame
+        data["df"] = pd.DataFrame(
+            {
+                "integer": np.random.randint(1, 100, size=10),
+                "float": np.random.random(10),
+            },
+            index=[f"x-{i}" for i in range(1, 11)],
+        )
+
     else:
         data["mock"] = False
 
@@ -64,27 +84,100 @@ def config(pytestconfig):
             database_id=TEST_DB_NAME,
         )
 
+        data["db-name"] = TEST_DB_NAME
+
     # tests run on yield
     yield data
 
     # teardown code
     if pytestconfig.getoption("client") != "mock":
-        clean_up_test_objects(TEST_PREFIX)
+        clean_up_test_objects(TEST_PREFIX + salt)
 
 
-def test_dataframe_operations(config):  # noqa: F811
+@pytest.mark.parametrize("column", COLUMNS)
+def test_dataframe_read_modify(config, column):  # noqa: F811
     """this function tests our ability to fetch data, modify it, and write it back"""
 
     if config["mock"]:
-        pytest.skip(
-            "Skipping this test because we can't test this well using a mocked client"
-        )
+        pytest.skip(SKIP_MSG)
 
-    # we are explicitly using a loop in here rather than
-    # pytest.parameterize because these tests run in parallel.
-    # this can cause race conditions where the teardown/setup code
-    # can be called simultaneously from two workers
-    for column in COLUMNS:
-        df = DataFrame.from_deeporigin(TEST_DB_NAME)
-        df["sq_" + column] = df[column] ** 2
+    df = DataFrame.from_deeporigin(config["db-name"])
+    df["sq_" + column] = df[column] ** 2
+    df.to_deeporigin()
+
+
+@pytest.mark.parametrize("column", COLUMNS)
+def test_dataframe_write_new_columns(config, column):  # noqa: F811
+    """this function tests our ability to write new columns to a database"""
+
+    if config["mock"]:
+        pytest.skip(SKIP_MSG)
+
+    df = DataFrame.from_deeporigin(config["db-name"])
+    df["cube_" + column] = df[column] ** 3
+    df.to_deeporigin()
+
+
+def test_slicing_restrictions(config):
+    """check that we control what happens when a dataframe is sliced by rows"""
+
+    if config["mock"]:
+        df = DataFrame(config["df"])
+    else:
+        df = DataFrame.from_deeporigin(config["db-name"])
+
+    assert df._allow_adding_rows is True, "Expected _allow_adding_rows to be True"
+
+    # slice to 2 rows
+    df = df.loc[df.index[:2]]
+
+    assert df._allow_adding_rows is False, "Expected _allow_adding_rows to be False"
+
+
+def test_slice_and_modify(config):
+    """check that we control what happens when a dataframe is sliced by rows"""
+
+    if config["mock"]:
+        df = DataFrame(config["df"])
+    else:
+        df = DataFrame.from_deeporigin(config["db-name"])
+
+    assert df._allow_adding_rows is True, "Expected _allow_adding_rows to be True"
+
+    # slice to 2 rows
+    df = df.loc[df.index[:2]]
+
+    assert df._allow_adding_rows is False, "Expected _allow_adding_rows to be False"
+
+    # we should be allowed to modify a slice
+    df.iloc[0]["integer"] = 100
+
+    if config["mock"]:
+        return
+
+    # should be allowed to write back to DB
+    df.to_deeporigin()
+
+
+def test_slice_and_extend_loc(config):
+    """test that we can add a row to a whole df, but not to a slice of it"""
+
+    if config["mock"]:
+        df = DataFrame(config["df"])
+        row_prefix = "x"
+    else:
+        df = DataFrame.from_deeporigin(config["db-name"])
+        row_prefix = df.attrs["metadata"]["hid_prefix"]
+
+    # should be possible to add a new row
+    df.loc[row_prefix + "-" + str(len(df) + 1)] = list(df.loc[df.index[0]])
+
+    if not config["mock"]:
         df.to_deeporigin()
+
+    # slice to 2 rows
+    df = df.loc[df.index[:2]]
+
+    # should not be possible to add a new row
+    with pytest.raises(ValueError, match="Adding rows is not allowed"):
+        df.loc[row_prefix + "-" + str(len(df) + 1)] = list(df.loc[df.index[0]])

--- a/tests/test_dataframe_kitchen_sink.py
+++ b/tests/test_dataframe_kitchen_sink.py
@@ -7,7 +7,7 @@ import pytest
 from deeporigin.data_hub import api
 from deeporigin.data_hub.dataframe import DataFrame
 
-from tests.utils import minimal_config as config
+from tests.utils import minimal_config as config  # noqa: F401
 
 
 def skip_if_unavailable(cfg):


### PR DESCRIPTION
## changes

- [x] loc indexer preservers attrs
- [x] add a new prop: `_allow_new_rows`
- [x] df indexed using loc should disallow adding new rows via loc

## in a future PR

- ability to write data back to DB when adding new rows
- support for appending a pandas dataframe