### PR TITLE
fix: attempt to fix custom domain reset

### DIFF
--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+client-docs.deeporigin.io


### PR DESCRIPTION
## problem

the custom domain keeps getting reset, and this is the supposed fix

https://github.com/tschaub/gh-pages/pull/375/commits/1e38a134d29b6c8104e74fdb6a4fb5201f65f49c

see also:

https://stackoverflow.com/questions/67183664/why-is-my-github-pages-custom-domain-constantly-reset