### PR TITLE
fix: only patch the action

### DIFF
--- a/.github/workflows/live_tests.yaml
+++ b/.github/workflows/live_tests.yaml
@@ -9,11 +9,27 @@ on:
     - cron: "0 0 * * *"
 
 jobs:
-  write-tokens:
+  test-live-instance:
     runs-on: ubuntu-latest
-    outputs:
-      api_tokens_path: ~/.deeporigin/api_tokens
+    env:
+      # Secrets for API and organization
+      DEEP_ORIGIN_REFRESH_TOKEN: ${{ secrets.DEEP_ORIGIN_REFRESH_TOKEN }}
+      DEEP_ORIGIN_ACCESS_TOKEN: ${{ secrets.DEEP_ORIGIN_ACCESS_TOKEN }}
+      DEEP_ORIGIN_ORGANIZATION_ID: ${{ secrets.DEEP_ORIGIN_ORGANIZATION_ID }}
+      DEEP_ORIGIN_API_ENDPOINT: ${{ secrets.DEEP_ORIGIN_API_ENDPOINT }}
+      DEEP_ORIGIN_NUCLEUS_API_ROUTE: ${{ secrets.DEEP_ORIGIN_NUCLEUS_API_ROUTE }}
+
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python environment
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: 'pip'
+          cache-dependency-path: pyproject.toml
+
       - name: Create API Tokens File
         run: |
           mkdir -p ~/.deeporigin
@@ -21,31 +37,12 @@ jobs:
             "refresh": "'$DEEP_ORIGIN_REFRESH_TOKEN'",
             "access": "'$DEEP_ORIGIN_ACCESS_TOKEN'"
           }' > ~/.deeporigin/api_tokens
-        env:
-          DEEP_ORIGIN_REFRESH_TOKEN: ${{ secrets.DEEP_ORIGIN_REFRESH_TOKEN }}
-          DEEP_ORIGIN_ACCESS_TOKEN: ${{ secrets.DEEP_ORIGIN_ACCESS_TOKEN }}
 
-  test-against-live-instance:
-    runs-on: ubuntu-latest
-    needs: write-tokens
-    env:
-      # Secrets for live instance
-      DEEP_ORIGIN_ORGANIZATION_ID: ${{ secrets.DEEP_ORIGIN_ORGANIZATION_ID }}
-      DEEP_ORIGIN_API_ENDPOINT: ${{ secrets.DEEP_ORIGIN_API_ENDPOINT }}
-      DEEP_ORIGIN_NUCLEUS_API_ROUTE: ${{ secrets.DEEP_ORIGIN_NUCLEUS_API_ROUTE }}
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-python@v5
-        id: cached_python_setup
-        with:
-          python-version: "3.11"
-          cache: 'pip'
-          cache-dependency-path: pyproject.toml
-
-      - name: Install dependencies and run tests
+      - name: Install dependencies
         run: |
           pip install --upgrade pip
           pip install --upgrade setuptools
           pip install -e .[test]
-          make test-github-live
+
+      - name: Run tests against a live instance
+        run: make test-github-live

--- a/.github/workflows/live_tests.yaml
+++ b/.github/workflows/live_tests.yaml
@@ -1,23 +1,38 @@
 name: Tests against a Live Instance
 
 on:
-  # allow manual runs
+  # Allow manual runs
   workflow_dispatch:
 
-  # run every day
+  # Run every day
   schedule:
-    - cron: "0 0 * * *" 
+    - cron: "0 0 * * *"
 
 jobs:
+  write-tokens:
+    runs-on: ubuntu-latest
+    outputs:
+      api_tokens_path: ~/.deeporigin/api_tokens
+    steps:
+      - name: Create API Tokens File
+        run: |
+          mkdir -p ~/.deeporigin
+          echo '{
+            "refresh": "'$DEEP_ORIGIN_REFRESH_TOKEN'",
+            "access": "'$DEEP_ORIGIN_ACCESS_TOKEN'"
+          }' > ~/.deeporigin/api_tokens
+        env:
+          DEEP_ORIGIN_REFRESH_TOKEN: ${{ secrets.DEEP_ORIGIN_REFRESH_TOKEN }}
+          DEEP_ORIGIN_ACCESS_TOKEN: ${{ secrets.DEEP_ORIGIN_ACCESS_TOKEN }}
+
   test-against-live-instance:
     runs-on: ubuntu-latest
+    needs: write-tokens
     env:
+      # Secrets for live instance
       DEEP_ORIGIN_ORGANIZATION_ID: ${{ secrets.DEEP_ORIGIN_ORGANIZATION_ID }}
       DEEP_ORIGIN_API_ENDPOINT: ${{ secrets.DEEP_ORIGIN_API_ENDPOINT }}
       DEEP_ORIGIN_NUCLEUS_API_ROUTE: ${{ secrets.DEEP_ORIGIN_NUCLEUS_API_ROUTE }}
-      DEEP_ORIGIN_ACCESS_TOKEN: ${{ secrets.DEEP_ORIGIN_ACCESS_TOKEN }}
-
-
     steps:
       - uses: actions/checkout@v4
 
@@ -28,7 +43,7 @@ jobs:
           cache: 'pip'
           cache-dependency-path: pyproject.toml
 
-      - name: "Running tests against a live instance..."
+      - name: Install dependencies and run tests
         run: |
           pip install --upgrade pip
           pip install --upgrade setuptools

--- a/.github/workflows/live_tests.yaml
+++ b/.github/workflows/live_tests.yaml
@@ -13,8 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       # Secrets for API and organization
-      DEEP_ORIGIN_REFRESH_TOKEN: ${{ secrets.DEEP_ORIGIN_REFRESH_TOKEN }}
-      DEEP_ORIGIN_ACCESS_TOKEN: ${{ secrets.DEEP_ORIGIN_ACCESS_TOKEN }}
+      REFRESH_TOKEN: ${{ secrets.DEEP_ORIGIN_REFRESH_TOKEN }}
+      ACCESS_TOKEN: ${{ secrets.DEEP_ORIGIN_ACCESS_TOKEN }}
       DEEP_ORIGIN_ORGANIZATION_ID: ${{ secrets.DEEP_ORIGIN_ORGANIZATION_ID }}
       DEEP_ORIGIN_API_ENDPOINT: ${{ secrets.DEEP_ORIGIN_API_ENDPOINT }}
       DEEP_ORIGIN_NUCLEUS_API_ROUTE: ${{ secrets.DEEP_ORIGIN_NUCLEUS_API_ROUTE }}
@@ -34,8 +34,8 @@ jobs:
         run: |
           mkdir -p ~/.deeporigin
           echo '{
-            "refresh": "'$DEEP_ORIGIN_REFRESH_TOKEN'",
-            "access": "'$DEEP_ORIGIN_ACCESS_TOKEN'"
+            "refresh": "'$REFRESH_TOKEN'",
+            "access": "'$ACCESS_TOKEN'"
           }' > ~/.deeporigin/api_tokens
 
       - name: Install dependencies
@@ -43,6 +43,10 @@ jobs:
           pip install --upgrade pip
           pip install --upgrade setuptools
           pip install -e .[test]
+
+      - name: Refresh API tokens using deeporigin.auth
+        run: |
+          python -c "from deeporigin import auth; auth.get_tokens(refresh=True)"
 
       - name: Run tests against a live instance
         run: make test-github-live


### PR DESCRIPTION
## what

tests against a live instance (that were configured to run daily) were broken because the access token kept going stale. 

this PR fixes this by manually refreshing before running tests. 

## proof 

https://github.com/deeporiginbio/deeporigin-client/actions/runs/12014629544
