### PR TITLE
feat: high level toolkit for running ligand and docking

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 * @deeporiginbio/client-developers 
+src/tools/* @deeporiginbio/tool-developers 

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ install:
 	@python3 -m venv venv
 	@source $(CURDIR)/venv/bin/activate && \
 		pip install --upgrade pip && \
-	    pip install --no-cache-dir -e .[lint,test,dev,docs,plots] && \
+	    pip install --no-cache-dir -e .[lint,test,dev,docs,plots,tools] && \
 	    deactivate
 	@-mkdir -p ~/.deeporigin
 	@test -f ~/.deeporigin/deeporigin || ln -s $(CURDIR)/venv/bin/deeporigin ~/.deeporigin/deeporigin

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ else
 endif 
 	@source $(CURDIR)/venv/bin/activate && \
 	interrogate -c pyproject.toml -v . -f 100 && \
-	python3 -m coverage run --source="src" -m pytest -x -n $(n_workers) --failed-first -k $(chosen_tests) --client $(client) --responses $(responses) && \
+	python3 -m coverage run --source="src" -m pytest -x -n $(n_workers) --failed-first -k $(chosen_tests) --client $(client) --responses $(responses) --dist loadfile && \
 	python3 -m coverage html && \
 	deactivate
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,6 @@ test = [
 dev = [
     "ipykernel",
     "jupyter-black",
-    "icecream",
 ]
 docs = [
     "mkdocs", 
@@ -65,6 +64,7 @@ docs = [
     "black"
 ]
 plots = ["bokeh"]
+tools = ["rdkit"]
 
 [tool.setuptools]
 package-dir = {"deeporigin" = "src"}

--- a/src/tools/run.py
+++ b/src/tools/run.py
@@ -237,7 +237,7 @@ def autodock_vina(
             "columnId": output_column_name,
             "databaseId": database_id,
         },
-        scores={
+        scores_file={
             "rowId": row_id,
             "columnId": scores_column_name,
             "databaseId": database_id,

--- a/src/tools/run.py
+++ b/src/tools/run.py
@@ -180,6 +180,7 @@ def autodock_vina(
     output_column_name: str,
     receptor_column_name: str,
     ligand_column_name: str,
+    scores_column_name: str,
 ) -> str:
     """starts an run of AutoDock Vina on the Deep Origin platform.
 
@@ -191,6 +192,7 @@ def autodock_vina(
         output_column_name (str): name of the column to write output file to
         receptor_column_name (str): name of the column to source the receptor file from
         ligand_column_name (str): name of the column to source the ligand file from
+        scores_column_name (str): name of the column to write scores to
 
     Returns:
         str: ID of the job. This ID can be used to query status.
@@ -233,6 +235,11 @@ def autodock_vina(
         output_file={
             "rowId": row_id,
             "columnId": output_column_name,
+            "databaseId": database_id,
+        },
+        scores={
+            "rowId": row_id,
+            "columnId": scores_column_name,
             "databaseId": database_id,
         },
     )

--- a/src/tools/toolkit.py
+++ b/src/tools/toolkit.py
@@ -1,0 +1,280 @@
+"""this module contains high level utility functions that makes it easier to use tools by providing wrappers over tools"""
+
+from beartype import beartype
+from deeporigin.data_hub import api
+from deeporigin.tools import run
+
+VINA_DB = "autodock-vina"
+LIGAND_PREP_DB = "ligand-prep-meeko"
+
+
+@beartype
+def _ensure_db_for_vina_outputs() -> None:
+    """makes a DB for outputs of vina"""
+
+    databases = api.list_rows(row_type="database")
+
+    cols = ["docked-ligand", "scores", "SMILES"]
+    col_types = ["file", "file", "text"]
+
+    database = [db for db in databases if db["hid"] == VINA_DB]
+
+    if len(database) == 0:
+        # make a new DB
+        database = api.create_database(
+            hid=VINA_DB,
+            hid_prefix="adv",
+            name=VINA_DB,
+        )
+
+    # get info about database
+    database = api.describe_database(database_id=VINA_DB)
+
+    existing_cols = []
+    if "cols" in list(database.keys()):
+        existing_cols = [col["name"] for col in database.cols]
+
+    # check if we need to make columns
+
+    for col, col_type in zip(cols, col_types):
+        if col in existing_cols:
+            continue
+        print(f"making {col}")
+
+        api.add_database_column(
+            cardinality="one",
+            database_id=VINA_DB,
+            name=col,
+            required=False,
+            type=col_type,
+        )
+
+
+@beartype
+def _ensure_db_for_ligand_prep_meeko() -> None:
+    databases = api.list_rows(row_type="database")
+
+    cols = ["input-ligand", "output-ligand"]
+
+    database = [db for db in databases if db["hid"] == LIGAND_PREP_DB]
+
+    if len(database) == 0:
+        # make a new DB
+        database = api.create_database(
+            hid=LIGAND_PREP_DB,
+            hid_prefix="lpm",
+            name=LIGAND_PREP_DB,
+        )
+
+    # get info about database
+    database = api.describe_database(database_id=LIGAND_PREP_DB)
+
+    existing_cols = []
+    if "cols" in list(database.keys()):
+        existing_cols = [col["name"] for col in database.cols]
+
+    # check if we need to make columns
+    for col in cols:
+        if col in existing_cols:
+            continue
+        print(f"making {col}")
+
+        api.add_database_column(
+            cardinality="one",
+            database_id=LIGAND_PREP_DB,
+            name=col,
+            required=False,
+            type="file",
+        )
+
+
+@beartype
+def smiles_to_sdf(smiles: str, sdf_path: str) -> None:
+    """convert a SMILES string to a SDF file"""
+
+    from rdkit import Chem
+    from rdkit.Chem import AllChem, SDWriter
+
+    mol = Chem.MolFromSmiles(smiles)
+    if mol is None:
+        print(f"Invalid SMILES: {smiles}")
+
+    try:
+        Chem.Kekulize(mol)
+    except ValueError:
+        print(f"Failed to kekulize: {smiles}")
+
+    mol = Chem.AddHs(mol)
+
+    AllChem.EmbedMolecule(mol, AllChem.ETKDG())
+    AllChem.UFFOptimizeMolecule(mol)
+
+    with SDWriter(sdf_path) as writer:
+        writer.write(mol)
+
+
+@beartype
+def csv_to_sdfs(
+    csv_file: str,
+    smiles_column_name: str,
+) -> list:
+    """given a CSV file, convert all SMILES strings in that CSV file to SDF files"""
+
+    import pandas as pd
+
+    df = pd.read_csv(csv_file)
+    smiles_list = list(df[smiles_column_name])
+
+    all_sdf_paths = []
+
+    for i, smiles in enumerate(smiles_list):
+        sdf_path = f"{str(i)}.sdf"
+        smiles_to_sdf(
+            smiles,
+            sdf_path=sdf_path,
+        )
+        all_sdf_paths.append(sdf_path)
+    return all_sdf_paths
+
+
+@beartype
+def prep_ligands(*, csv_file: str, column_name: str):
+    """high level function to prepare ligands from a CSV file with SMILES strings using Lingand Prep Meeko Tool on Deep Origin"""
+
+    _ensure_db_for_ligand_prep_meeko()
+
+    sdf_files = csv_to_sdfs(csv_file, column_name)
+
+    row_ids = []
+
+    for sdf_file in sdf_files:
+        print(f"Uploading {sdf_file}...")
+        response = api.upload_file_to_new_database_row(
+            database_id=LIGAND_PREP_DB,
+            column_id="input-ligand",
+            file_path=sdf_file,
+        )
+
+        row_ids.append(response.rows[0].hid)
+
+    run_ligand_prep_on_db(
+        database_id=LIGAND_PREP_DB,
+        input_column_name="input-ligand",
+        output_column_name="output-ligand",
+    )
+
+
+def run_ligand_prep_on_db(
+    *,
+    database_id: str,
+    input_column_name: str,
+    output_column_name: str,
+):
+    """utility function to run Ligand Prep (Meeko) on all ligands in a database"""
+
+    database = api.describe_database(database_id=database_id)
+    rows = api.list_database_rows(database_row_id=database_id)
+    col_mapper = {col["name"]: col["id"] for col in database.cols}
+
+    for row in rows:
+        columns_with_files = [field["columnId"] for field in row.fields]
+
+        if (
+            col_mapper["input-ligand"] in columns_with_files
+            and col_mapper["output-ligand"] not in columns_with_files
+        ):
+            run.ligand_prep(
+                database_id=database_id,
+                ligand_column_name=input_column_name,
+                output_column_name=output_column_name,
+                row_id=row.hid,
+            )
+
+
+@beartype
+def dock_ligands_to_protein(
+    *,
+    ligand_database_name: str,
+    ligand_column_name: str,
+    protein_database_name: str,
+    protein_column_name: str,
+    protein_row: str,
+    search_space: dict,
+    docking: dict,
+):
+    """Dock all ligands in a ligand database to a prepped protein in a protein database, and store those results in a new database"""
+
+    _ensure_db_for_vina_outputs()
+
+    # figure out which rows of the ligand DB are valid
+    ligand_db = api.describe_database(database_id=ligand_database_name)
+    protein_db = api.describe_database(database_id=protein_database_name)
+    vina_db = api.describe_database(database_id=VINA_DB)
+    ligand_rows = api.list_database_rows(database_row_id=ligand_database_name)
+
+    if len(ligand_rows) == 0:
+        raise ValueError("No rows in ligand DB")
+
+    col_mapper = {col["name"]: col["id"] for col in ligand_db.cols}
+
+    rows_with_ligand = []
+
+    for row in ligand_rows:
+        columns_with_files = [field["columnId"] for field in row.fields]
+
+        if col_mapper[ligand_column_name] in columns_with_files:
+            rows_with_ligand.append(row.hid)
+
+    # make new rows, as many as there are rows_with_ligand
+    n_rows = len(rows_with_ligand)
+    if n_rows == 0:
+        raise ValueError(
+            "There are no valid ligands that can be used as inputs to Vina in the ligand DB"
+        )
+
+    print(f"Making {n_rows} new rows in the {VINA_DB} database to hold outputs...")
+    response = api.make_database_rows(
+        database_id=VINA_DB,
+        n_rows=n_rows,
+    )
+
+    output_rows = [row["hid"] for row in response.rows]
+
+    # for each row with ligand, run a vina job
+    for ligand_row, output_row in zip(
+        rows_with_ligand,
+        output_rows,
+    ):
+        inputs = dict(
+            receptor={
+                "rowId": protein_row,
+                "columnId": protein_column_name,
+                "databaseId": protein_database_name,
+            },
+            ligand={
+                "rowId": ligand_row,
+                "columnId": ligand_column_name,
+                "databaseId": ligand_database_name,
+            },
+            searchSpace=search_space,
+            docking=docking,
+        )
+        outputs = dict(
+            output_file={
+                "rowId": output_row,
+                "columnId": "docked-ligand",
+                "databaseId": VINA_DB,
+            },
+            scores_file={
+                "rowId": output_row,
+                "columnId": "scores",
+                "databaseId": VINA_DB,
+            },
+        )
+
+        run._process_job(
+            cols=protein_db.cols + ligand_db.cols + vina_db.cols,
+            inputs=inputs,
+            outputs=outputs,
+            tool_id="deeporigin/autodock-vina",
+        )

--- a/src/tools/toolkit.py
+++ b/src/tools/toolkit.py
@@ -177,7 +177,10 @@ def run_ligand_prep_on_db(
     col_mapper = {col["name"]: col["id"] for col in database.cols}
 
     for row in rows:
-        columns_with_files = [field["columnId"] for field in row.fields]
+        if "fields" in row.keys():
+            columns_with_files = [field["columnId"] for field in row.fields]
+        else:
+            columns_with_files = []
 
         if (
             col_mapper["input-ligand"] in columns_with_files

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -1,9 +1,7 @@
 from deeporigin.config import get_value
 
-from tests.utils import (  # noqa: F401
-    _run_cli_command,
-    config,
-)
+from tests.utils import _run_cli_command
+from tests.utils import minimal_config as config  # noqa: F401
 
 
 def test_set_config(config):  # noqa: F811

--- a/tests/test_cli_data.py
+++ b/tests/test_cli_data.py
@@ -64,9 +64,9 @@ def test_describe_row(config, option):  # noqa: F811
     if option == ["--json"]:
         data = _check_json(stdout)
 
-        assert (
-            data["hid"] == row_id
-        ), f"Expected row ID to match. However, got {data['id']} vs. {row_id}"
+        assert data["hid"] == row_id, (
+            f"Expected row ID to match. However, got {data['id']} vs. {row_id}"
+        )
 
 
 @pytest.mark.parametrize("json_option", JSON_OPTIONS)

--- a/tests/test_cli_data.py
+++ b/tests/test_cli_data.py
@@ -64,9 +64,9 @@ def test_describe_row(config, option):  # noqa: F811
     if option == ["--json"]:
         data = _check_json(stdout)
 
-        assert data["hid"] == row_id, (
-            f"Expected row ID to match. However, got {data['id']} vs. {row_id}"
-        )
+        assert (
+            data["hid"] == row_id
+        ), f"Expected row ID to match. However, got {data['id']} vs. {row_id}"
 
 
 @pytest.mark.parametrize("json_option", JSON_OPTIONS)


### PR DESCRIPTION
## changes

- [x] high level toolkit functions
- [x] support for scores for vina

## usage

```py
from deeporigin.tools import toolkit
csv_file = "/Users/srinivas/Downloads/ligands.csv"
column_name = "SMILES"
toolkit.prep_ligands(
    csv_file=csv_file,
    column_name=column_name,
)
```
^ this takes in a CSV file, converts every smiles string to a SDF file, uploads them to datahub, and preps them all using meeko (on deeporigin)

```py
ligand_database_name = "ligand-prep-meeko"
ligand_column_name = "output-ligand"
protein_database_name = "protein"
protein_column_name = "protein"
protein_row = "protein-1"

search_space = {
    "center_x": 15.190,
    "center_y": 53.903,
    "center_z": 16.917,
    "size_x": 15.1,
    "size_y": 15.1,
    "size_z": 15.1,
}

docking = {
    "energy_range": 3.1,
    "exhaustiveness": 1,
    "num_modes": 3,
}

toolkit.dock_ligands_to_protein(
    docking=docking,
    search_space=search_space,
    protein_row=protein_row,
    protein_column_name=protein_column_name,
    ligand_database_name=ligand_database_name,
    ligand_column_name=ligand_column_name,
    protein_database_name=protein_database_name,
)
```

^ this takes a bunch of prepped ligands in a database (created using previous step), and a protein in a protein DB (that was previously prepped using tools) and docks them all in parallel. 


