### PR TITLE
feat: improvements to docking tools

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,71 @@
 
 ## `deeporigin v3.14.0`
 
+- Ability to visualize proteins in 3D
+- Ability to visualize ligands in 3D
+- Ability to view docked poses with protein
+- New streamlined and improved class structure for `Complex`
+
+## `deeporigin v3.13.0`
+
+- Ability to visualize proteins in 3D
+
+## `deeporigin v3.12.0`
+
+- Streamlined easy install powered by `uv`
+- Numerous small improvements and bugfixes to FEP and Docking tools
+
+## `deeporigin v3.11.0`
+
+- New `Complex` class to work with RBFE, ABFE and Docking
+
+## `deeporigin v3.10.0`
+
+- Initial support for docking
+
+## `deeporigin v3.9.0`
+
+- Ability to read user defined properties from a SDF file
+- Improvements and bugfixes to ABFE
+
+## `deeporigin v3.8.0`
+
+- Unified class that can do both ABFE and RBFE
+
+## `deeporigin v3.7.0`
+
+- Updated to use more modern sonarlint
+- Updated to more modern ruff
+- Included FEP parameters as JSON
+- The `chemistry` module: tools to work with SDF files
+- Support for end-to-end ABFE
+- Ability to render mermaid graphs of FEP flow
+
+## `deeporigin v3.6.0`
+
+- Fixed a bug stemming from unconstrained urllib versions
+- Fixed a bug in wrappers for platform APIs
+
+## `deeporigin v3.5.0`
+
+- Initial support for ABFE
+
+## `deeporigin v3.4.0`
+
+- Changed scope of tests to better work in parallel
+- Added `tools` extra
+- Support for the core toolkit
+
+## `deeporigin v3.3.0`
+
+- Parallelization of job query and download
+- Ability to wait for jobs to finish
+
+## `deeporigin v3.2.0`
+
+- Added the PDB to PDBQT tool
+- Bugfixes to platform API tools
+
 ## `deeporigin v3.1.0`
 
 !!! warning "Deleted functions"

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## `deeporigin v3.14.0`
+
 ## `deeporigin v3.1.0`
 
 !!! warning "Deleted functions"

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,14 @@
 # Changelog
 
+
+## `deeporigin v3.15.0`
+
+- Ability to provide user with a SDF of all ligands that have been docked
+- When viewing docking results, output now includes user-supplied properties
+- Ability to filter SDF so that we only get structures for some list of smiles strings
+- Ability to limit the number of rows shown by `show_ligands`
+- Docs update showing users how to visualize protein in Complex
+
 ## `deeporigin v3.14.0`
 
 - Ability to visualize proteins in 3D

--- a/docs/dd/how-to/complex.md
+++ b/docs/dd/how-to/complex.md
@@ -1,0 +1,31 @@
+This document describes how to create a `Complex` object, that can be used to run Docking, ABFE and RBFE. 
+
+## From a directory 
+
+```python
+from deeporigin.drug_discovery import Complex
+
+# here, we're using the example data directory
+sim = Complex.from_dir(EXAMPLE_DATA_DIR)
+```
+
+The directory should contain:
+
+- exactly one PDB file 
+- `N` SDF files, with one molecule per SDF file
+
+## From `Protein` and `Ligand` objects
+
+A `Complex` object can be also be constructed using `Protein` and `Ligand` objects. 
+
+```python
+from deeporigin.drug_discovery import Complex
+
+sim = Complex(protein=protein, ligands=ligands)
+```
+
+??? tip "Constructing Ligands"
+    To see how to construct Ligands, see [this](./ligands.md)
+
+??? tip "Constructing the Protein"
+    To see how to construct the Protein, see [this](./proteins.md)

--- a/docs/dd/how-to/filter-docking-outputs.md
+++ b/docs/dd/how-to/filter-docking-outputs.md
@@ -1,0 +1,63 @@
+This document describes how to filter the outputs of Docking based on various properties. 
+
+Here we assume that you have constructed a `Complex` object and successfully run [Docking](../tutorial/docking.md). 
+Following convention, we assume that the `Complex` object is called `sim`.
+
+## Fetch Docking results
+
+First, we get the results of Docking in a pandas DataFrame using:
+
+```python
+df = sim.docking.get_results()
+```
+## Fetch combined SDF
+
+We can generate a single SDF file with all the poses using:
+
+```python
+sim.docking.get_poses("poses.sdf")
+```
+
+## Filter results   
+
+We can now filter this dataframe using any criteria we want. For example, we can only retain ligands that have a `pose_score` greater than `0.9` using:
+
+```python
+df = df[df["pose_score"] > 0.9]
+```
+
+The filtered dataframe now only has ligands that matches the required criterion. 
+
+
+
+## Filter SDF by SMILES strings
+
+We can create a new SDF file with only these ligands using:
+
+```python
+from deeporigin.drug_discovery import chemistry
+
+chemistry.filter_sdf_by_smiles(
+    input_sdf_file="poses.sdf",
+    output_sdf_file="filtered_ligands.sdf",
+    keep_only_smiles=df["SMILES"],
+)
+```
+
+We can visualize these ligands using:
+
+```python
+from deeporigin.drug_discovery import chemistry
+
+chemistry.show_molecules_in_sdf_file("filtered_ligands.sdf")
+```
+
+A visualization similar to the following will be shown:
+
+<iframe 
+    src="./brd-ligands.html" 
+    width="100%" 
+    height="650" 
+    style="border:none;"
+    title="Ligands visualization"
+></iframe>

--- a/docs/dd/how-to/ligands.md
+++ b/docs/dd/how-to/ligands.md
@@ -27,6 +27,46 @@ from deeporigin.chemistry import Ligand
 ligand = Ligand(smiles_string="[H]C1=C([H])C(C(=O)N(C([H])([H])[H])C([H])([H])[H])=C([H])C(C2=C([H])N(C([H])([H])[H])C(=O)C3=C2C([H])=C([H])N3[H])=C1[H]")
 ```
 
+### From a CSV file
+
+You can create multiple ligands at once from a CSV file using the `from_csv` class method. This is useful when you have a dataset of molecules with their SMILES strings and associated properties. The `from_csv` method:
+
+- Requires a path to the CSV file and the name of the column containing SMILES strings
+- Optionally accepts a list of column names to extract as properties
+- Skips rows with empty or invalid SMILES
+- Returns a list of `Ligand` objects
+
+This approach is ideal for processing large datasets of molecules where each row represents a different compound.
+
+#### Basic Usage
+
+For the simplest case, just specify the file path and which column contains the SMILES strings:
+
+```python
+from deeporigin.chemistry import Ligand
+
+# Basic usage - just extracting SMILES from a column
+ligands = Ligand.from_csv(
+    file="molecules.csv",
+    smiles_column="SMILES"
+)
+```
+
+#### Including Properties
+
+You can also extract additional properties from other columns in the CSV file:
+
+```python
+ligands = Ligand.from_csv(
+    file="molecules.csv",
+    smiles_column="SMILES",
+    properties_columns=["Name", "MW", "LogP", "Activity"]
+)
+```
+
+This will store all the specified column values as properties for each ligand, making it easy to keep track of important molecular characteristics alongside the structure information.
+
+
 
 ## Visualizing a ligand
 

--- a/docs/dd/how-to/use-docking-outputs-for-fep.md
+++ b/docs/dd/how-to/use-docking-outputs-for-fep.md
@@ -1,0 +1,34 @@
+This document describes how to use the outputs of Docking as inputs to FEP tools.
+
+## Assumptions
+
+We assume that you have 
+
+1. [:material-page-previous: created a `Complex` object](../tutorial/getting-started.md)
+2. [:material-page-previous: run Docking](../tutorial/docking.md)
+3. [:material-page-previous: Generated a SDF file with docked poses](../tutorial/docking.md#exporting-a-sdf-with-docked-poses)
+
+## Split Docking outputs SDF file
+
+Docking generates a single SDF file with all the ligands in it. FEP tools (ABFE and RBFE) require SDF files with individual molecules in their own SDF file. To get here, we use a utility function as follows:
+
+```python
+from deeporigin.drug_discovery import chemistry
+
+sdf_files = chemistry.split_sdf_file(
+    input_sdf_path="filtered_ligands.sdf", 
+)
+```
+
+`sdf_files` contains a list of paths to the generated SDF files. 
+
+We can use this to generate a new list of Ligands and modify the `Complex`
+
+
+```python
+from deeporigin.drug_discovery import Ligand
+
+sim.ligands = [Ligand(file) for file in files]
+```
+
+This object can be used to run [:material-page-previous: ABFE](../tutorial/abfe.md) or [:material-page-previous:RBFE](../tutorial/rbfe.md). 

--- a/docs/dd/how-to/visualize.md
+++ b/docs/dd/how-to/visualize.md
@@ -1,5 +1,32 @@
 This document describes how to visualuze proteins and ligands constructed using the Protein and Ligand classes, and tools to visualize SDF files.
 
+## Visualizing a protein
+
+??? warning "Browser support"
+    These visualizations work best on Google Chrome. We are aware of issues on other browsers, especially Safari on macOS.
+
+A protein object can be visualized using `show`:
+
+```python
+protein.show()
+```
+
+A visualization such as this will be shown:
+
+<iframe 
+    src="./protein.html" 
+    width="100%" 
+    height="600" 
+    style="border:none;"
+    title="Protein visualization"
+></iframe>
+
+!!! info "Jupyter notebook required"
+    Visualizations such as these require this code to be run in a jupyter notebook. We recommend using [these instructions](../../install.md) to install Jupyter.
+
+
+
+
 ## Ligands
 
 ### `Ligand` objects

--- a/docs/dd/how-to/visualize.md
+++ b/docs/dd/how-to/visualize.md
@@ -25,7 +25,7 @@ A visualization such as this will be shown:
     width="100%" 
     height="650" 
     style="border:none;"
-    title="ligand visualization"
+    title="Ligand visualization"
 ></iframe>
 
 !!! info "Jupyter notebook required"
@@ -52,6 +52,6 @@ show_molecules_in_sdf_file("path/to/file.sdf")
     width="100%" 
     height="650" 
     style="border:none;"
-    title="Protein visualization"
+    title="Ligands visualization"
 ></iframe>
 

--- a/docs/dd/tutorial/docking.md
+++ b/docs/dd/tutorial/docking.md
@@ -114,3 +114,13 @@ To obtain the raw dataframe for further analysis, use:
 ```python
 df = sim.docking.get_results()
 ```
+
+### Exporting a SDF with docked poses
+
+To export a SDF with docked poses, use:
+
+```python
+sim.docking.get_poses("/path/to/output.sdf")
+```
+
+This generates a SDF file with the docked poses for all ligands in the Complex. 

--- a/docs/dd/tutorial/getting-started.md
+++ b/docs/dd/tutorial/getting-started.md
@@ -42,6 +42,8 @@ The `Complex` object can be created using:
 sim = Complex.from_dir(EXAMPLE_DATA_DIR)
 ```
 
+## Inspecting the `Complex` object
+
 Inspecting the object shows that it contains a protein and 8 ligands:
 
 ```python
@@ -53,6 +55,25 @@ sim
     ```python
     Complex(protein=brd.pdb with 8 ligands)
     ```
+
+### Viewing the protein
+
+The 3D structure of the protein can be viewed using the built-in `show` method in the `Protein` class:
+
+```python
+sim.protein.show()
+```
+
+This generates a 3D visualization of the protein, similar to:
+
+<iframe 
+    src="../how-to/protein.html" 
+    width="100%" 
+    height="650" 
+    style="border:none;"
+    title="Protein visualization"
+></iframe>
+
 
 ### Listing Ligands
 

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -49,9 +49,12 @@ nav:
     - ABFE: dd/tutorial/abfe.md
     - RBFE: dd/tutorial/rbfe.md
   - How To:
+    - Create a Complex: dd/how-to/complex.md
     - Work with proteins: dd/how-to/proteins.md
     - Work with ligands: dd/how-to/ligands.md
     - Visualize proteins and ligands: dd/how-to/visualize.md
+    - Filter outputs of Docking: dd/how-to/filter-docking-outputs.md
+    - Use outputs of Docking for FEP: dd/how-to/use-docking-outputs-for-fep.md
   - Reference: 
     - chemistry: dd/ref/chemistry.md
     - complex: dd/ref/complex.md

--- a/src/drug_discovery/chemistry.py
+++ b/src/drug_discovery/chemistry.py
@@ -782,12 +782,10 @@ def filter_sdf_by_smiles(
     Extracts the SMILES strings of all valid molecules from an SDF file using RDKit.
 
     Args:
-        sdf_file (str | Path): Path to the SDF file.
+        input_sdf_file (str | Path): Path to the SDF file.
         output_sdf_file (str | Path): Path to the output SDF file.
         keep_only_smiles (list[str] | pd.Series): List or Series of SMILES strings to keep.
 
-    Returns:
-        list[str]: A list of SMILES strings for all valid molecules in the file.
     """
     writer = Chem.SDWriter(str(output_sdf_file))
 

--- a/src/drug_discovery/chemistry.py
+++ b/src/drug_discovery/chemistry.py
@@ -18,6 +18,7 @@ from dataclasses import dataclass, fields
 from pathlib import Path
 from typing import Optional, Tuple
 
+import pandas as pd
 from beartype import beartype
 from deeporigin.exceptions import DeepOriginException
 from rdkit import Chem
@@ -118,7 +119,6 @@ class Ligand:
         Returns:
             List of Ligand objects
         """
-        import pandas as pd
 
         # Read the CSV file
         df = pd.read_csv(file)
@@ -775,19 +775,24 @@ def filter_sdf_by_smiles(
     *,
     input_sdf_file: str | Path,
     output_sdf_file: str | Path,
-    keep_only_smiles: list[str],
+    keep_only_smiles: list[str] | pd.Series,
 ):
     """
     Extracts the SMILES strings of all valid molecules from an SDF file using RDKit.
 
     Args:
         sdf_file (str | Path): Path to the SDF file.
+        output_sdf_file (str | Path): Path to the output SDF file.
+        keep_only_smiles (list[str] | pd.Series): List or Series of SMILES strings to keep.
 
     Returns:
         list[str]: A list of SMILES strings for all valid molecules in the file.
     """
-
     writer = Chem.SDWriter(str(output_sdf_file))
+
+    # Convert pandas Series to list if necessary
+    if isinstance(keep_only_smiles, pd.Series):
+        keep_only_smiles = keep_only_smiles.tolist()
 
     keep_only_smiles = [canonicalize_smiles(smiles) for smiles in keep_only_smiles]
 

--- a/src/drug_discovery/chemistry.py
+++ b/src/drug_discovery/chemistry.py
@@ -430,6 +430,7 @@ def read_property_values(sdf_file: str | Path, key: str):
 
 @beartype
 def split_sdf_file(
+    *,
     input_sdf_path: str | Path,
     output_prefix: str = "ligand",
     output_dir: Optional[str | Path] = None,

--- a/src/drug_discovery/complex.py
+++ b/src/drug_discovery/complex.py
@@ -318,7 +318,7 @@ class Complex:
             p.text(")")
 
     @beartype
-    def show_ligands(self, *, view="2d", limit: Optional[int] = None):
+    def show_ligands(self, *, view: str = "2d", limit: Optional[int] = None):
         """Display ligands in the complex object.
 
         Args:

--- a/src/drug_discovery/docking.py
+++ b/src/drug_discovery/docking.py
@@ -82,6 +82,18 @@ class Docking:
 
         JupyterViewer.visualize(html_content)
 
+    def get_poses(self, output_sdf_file: str) -> None:
+        """generate a single SDF file containing all the poses of all ligands docked to the protein
+
+        Args:
+            output_sdf_file (str): path to output SDF file. All poses will be written to a SDF file in this location.
+
+        """
+
+        files = self.parent.get_result_files_for("Docking")
+
+        chem.merge_sdf_files(files, output_sdf_file)
+
     @beartype
     def run(
         self,

--- a/tests/test_chemistry.py
+++ b/tests/test_chemistry.py
@@ -124,3 +124,36 @@ def test_download_protein():
     assert os.path.exists(pdb_file), "The downloaded PDB file does not exist."
 
     os.remove(pdb_file)
+
+
+@pytest.mark.parametrize("ligand", ligands)
+def test_filter_sdf_by_smiles(ligand):
+    # Define the whitelist of canonical SMILES to filter by.
+    # Replace these placeholder values with actual canonical SMILES strings.
+
+    if ligand["n_ligands"] == 1:
+        return
+
+    smiles = chemistry.sdf_to_smiles(ligand["file"])
+
+    smiles = smiles[:5]
+
+    output_sdf = "temp.sdf"
+
+    # Call the filtering function.
+    chemistry.filter_sdf_by_smiles(
+        input_sdf_file=ligand["file"],
+        output_sdf_file=output_sdf,
+        keep_only_smiles=smiles,
+    )
+
+    # Read back the filtered SDF file.
+    actual_smiles = chemistry.sdf_to_smiles(output_sdf)
+
+    actual_smiles = [chemistry.canonicalize_smiles(smi) for smi in actual_smiles]
+
+    smiles = [chemistry.canonicalize_smiles(smi) for smi in smiles]
+
+    assert set(actual_smiles) == set(smiles)
+
+    os.remove(output_sdf)


### PR DESCRIPTION
## changes

- [x] ability to provide user with a SDF of all ligands that have been docked
- [x] ability to filter SDF so that we only get structures for some list of smiles strings
- [x] New how to section showing how we can dock a bunch of ligands, and then use docking results to filter them for FEP
- [x] up-to-date changelog
- [x] ability to limit the number of rows shown by show_ligands 
- [x] docs update showing users how to visualize protein in Complex