### PR TITLE
feat: named runs for ABFE

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     "pyjwt",
     "cryptography",
     "python-box",
-    "do-sdk-platform==3.1.0",
+    "do-sdk-platform==3.2.0",
     "urllib3>=2.0.0",
     "more-itertools",
     "nest_asyncio",

--- a/src/drug_discovery/abfe.py
+++ b/src/drug_discovery/abfe.py
@@ -2,6 +2,7 @@
 
 The ABFE object instantiated here is contained in the Complex class is meant to be used within that class."""
 
+import json
 import os
 import pathlib
 from typing import Literal, Optional
@@ -235,6 +236,7 @@ class ABFE:
         ]
 
         data = job._progress_reports[0]
+        data = json.loads(data)
 
         if data is None:
             progress = {step: "NotStarted" for step in steps}
@@ -268,9 +270,9 @@ class ABFE:
         return progress
 
     @classmethod
-    def show_progress(cls, job):
+    def show_progress(cls, job) -> str:
         """
-        Render a Mermaid diagram where each node is drawn as arounded rectangle
+        Render HTML for a Mermaid diagram where each node is drawn as arounded rectangle
         with a color indicating its status.
 
         Any node not specified in the node_status dict willdefault to "notStarted".
@@ -279,6 +281,13 @@ class ABFE:
         from deeporigin.utils.notebook import mermaid_to_html
 
         statuses = cls.parse_progress(job)
+
+        header_html = f"""
+        <div style="text-align: left; font-family: sans-serif;">
+            <h2>ABFE run using <code>{job._metadata[0]["protein_id"]}</code> and <code>{job._metadata[0]["ligand1_id"]}</code></h2>
+            <p>Job ID: <code>{job._ids[0]}</code></p>
+        </div>
+        """
 
         # Define the fixed nodes in the diagram.
         nodes = [
@@ -322,7 +331,7 @@ class ABFE:
         """
 
         # Render the diagram using your helper function.
-        html = mermaid_to_html(mermaid_code)
+        mermaid_html = mermaid_to_html(mermaid_code)
 
         # Define HTML for the legend. Each status is displayed asa colored span.
         legend_html = """
@@ -334,4 +343,4 @@ class ABFE:
         </div>
         """
         # Display the legend below the Mermaid diagram.
-        return html + legend_html
+        return header_html + mermaid_html + legend_html

--- a/src/tools/utils.py
+++ b/src/tools/utils.py
@@ -43,6 +43,7 @@ def get_status_and_progress(execution_id: str) -> dict:
         progress=data.attributes.progressReport,
         execution_id=execution_id,
         inputs=data.attributes.userInputs,
+        attributes=data.attributes,
     )
 
 
@@ -69,6 +70,8 @@ def get_statuses_and_progress(job_ids: list[str]) -> list:
                 results.append(future.result())
             except Exception:
                 pass
+
+    return results
 
 
 @beartype


### PR DESCRIPTION
## changes

- [x] ABFE runs are now named
- [x] name used to show a nice display of a job
- [x] this nicely integrates with the asyncio-driven code, allowing for a live (!) display that auto-updates

<img width="892" alt="Screenshot 2025-04-09 at 3 18 03 PM" src="https://github.com/user-attachments/assets/4dc8249d-dc40-4a0d-af4a-7667fb0acc9b" />
