### PR TITLE
Updated scratch folder creation to respect concurrent runs.

### DIFF
--- a/src/utils/core.py
+++ b/src/utils/core.py
@@ -468,8 +468,7 @@ def _ensure_do_folder() -> Path:
     else:
         deeporigin_path = Path.home() / ".deeporigin"
 
-    if not deeporigin_path.exists():
-        deeporigin_path.mkdir(parents=True)
+    deeporigin_path.mkdir(parents=True, exist_ok=True)
 
     return deeporigin_path
 


### PR DESCRIPTION
This pull request simplifies the directory creation logic in the `_ensure_do_folder` function within `src/utils/core.py`, and should fix the problem of concurrent execution of `_ensure_do_folder`.

Code improvement:

* [`src/utils/core.py`](diffhunk://#diff-6dd63dcba1e65fa1db77ad1cdc2cc81450272b70ba50d1825d752017aa26615bL471-R471): Replaced the conditional check for directory existence and creation with a single call to `mkdir` using the `exist_ok=True` parameter, which ensures the directory is created if it doesn't exist and avoids redundant checks.