### PR TITLE
fix: FilesClient.get_auth_ok; debug launch params

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,12 +2,17 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "Python: Debug Current File (WSL)",
+            "name": "Python: Debug Current File",
             "type": "python",
             "request": "launch",
             "program": "${file}",
             "console": "integratedTerminal",
-            "justMyCode": true
+            "justMyCode": true,
+            "python": "${workspaceFolder}/venv/bin/python",
+            "env": {
+                "VIRTUAL_ENV": "${workspaceFolder}/venv",
+                "PATH": "${workspaceFolder}/venv/bin:${env:PATH}"
+            }
         }
     ]
 }

--- a/src/files/files_client.py
+++ b/src/files/files_client.py
@@ -1082,10 +1082,9 @@ class FilesClient:
         """
         try:
             # Try to list objects in a default location
-            org_friendly_id = "default"
 
             call_args = genapi._get_get_object_kwargs(
-                orgFriendlyId=org_friendly_id,
+                orgFriendlyId=self.organization_id,
                 filePath="",
                 list_type=2,  # Default list type
             )


### PR DESCRIPTION
Fixed get_auth_ok in files client to use correct organization.

Launch debug params updated for venv.