### PR TITLE
chore: refactored functions to use a common hashing strategy

### DIFF
--- a/src/drug_discovery/structures/protein.py
+++ b/src/drug_discovery/structures/protein.py
@@ -249,7 +249,7 @@ class Protein(Entity):
     def model_loops(self) -> None:
         """model loops in protein structure"""
 
-        from deeporigin.functions.loop_modelling import _model_loops
+        from deeporigin.functions.loop_modelling import model_loops as _model_loops
 
         pdb_id = self.pdb_id
 
@@ -266,6 +266,7 @@ class Protein(Entity):
         *,
         ligand: Ligand,
         pocket: Pocket,
+        use_cache: bool = True,
     ) -> str:
         """Dock a ligand into a specific pocket of the protein.
 
@@ -288,6 +289,7 @@ class Protein(Entity):
             protein=self,
             ligand=ligand,
             pocket=pocket,
+            use_cache=use_cache,
         )
 
         return docked_ligand_sdf_file
@@ -458,6 +460,7 @@ class Protein(Entity):
         self,
         pocket_count: int = 1,
         pocket_min_size: int = 30,
+        use_cache: bool = True,
     ) -> list[Pocket]:
         """Find potential binding pockets in the protein structure.
 
@@ -492,6 +495,7 @@ class Protein(Entity):
             protein=self,
             pocket_count=pocket_count,
             pocket_min_size=pocket_min_size,
+            use_cache=use_cache,
         )
 
         return Pocket.from_pocket_finder_results(results_dir)

--- a/src/drug_discovery/structures/protein.py
+++ b/src/drug_discovery/structures/protein.py
@@ -246,7 +246,7 @@ class Protein(Entity):
 
         return sequences
 
-    def model_loops(self) -> None:
+    def model_loops(self, use_cache: bool = True) -> None:
         """model loops in protein structure"""
 
         from deeporigin.functions.loop_modelling import model_loops as _model_loops
@@ -256,7 +256,7 @@ class Protein(Entity):
         if pdb_id is None:
             raise ValueError("Currently, PDB ID is required to model loops.")
 
-        file_path = _model_loops(pdb_id=pdb_id)
+        file_path = _model_loops(pdb_id=pdb_id, use_cache=use_cache)
         protein = Protein.from_file(file_path)
         self.structure = protein.structure
 
@@ -297,53 +297,6 @@ class Protein(Entity):
     @property
     def coordinates(self):
         return self.structure.coord
-
-    # @beartype
-    # def prepare(self, model_loops: bool = False, pdb_id: str = "") -> "Protein":
-    #     """
-    #     Prepares the protein by calling the 'prepare' function with the specified protein path, PDB ID, and extension.
-    #     It extracts metal and cofactor residue names from the protein structure and passes them to the 'prepare' function.
-
-    #     Returns:
-    #         protein (Protein): The prepared Protein object.
-    #     Raises:
-    #         Exception: If the preparation of the protein fails.
-    #     """
-    #     pdb_id = pdb_id if pdb_id else self.pdb_id
-    #     if model_loops and not pdb_id:
-    #         raise ValueError("PDB ID must be provided to model loops.")
-
-    #     metal_resnames, cofactor_resnames = self.extract_metals_and_cofactors()
-    #     metals_to_keep = [
-    #         resname for resname in metal_resnames if resname.upper() in METALS
-    #     ]
-
-    #     response = prepare(
-    #         protein_path=self.file_path,
-    #         protein_pdb_id=pdb_id,
-    #         protein_extension=self.block_type,
-    #         metal_resnames=metals_to_keep,
-    #         cofactor_resnames=cofactor_resnames,
-    #         model_loops=model_loops,
-    #     )
-    #     if not response["prepared_protein_content"]:
-    #         raise Exception("Failed to prepare protein.")
-
-    #     protein_dir = Path(self.file_path).parent
-    #     base_name = (
-    #         Path(self.file_path).stem if self.file_path else "modified_structure"
-    #     )
-    #     new_file_name = protein_dir / f"{base_name}_prep.pdb"
-
-    #     intermediate_protein = Protein(
-    #         block_content=response["prepared_protein_content"], block_type="pdb"
-    #     )
-    #     intermediate_protein.write_to_file(str(new_file_name))
-
-    #     protein = Protein(file_path=new_file_name)
-    #     protein.pdb_id = self.pdb_id
-
-    #     return protein
 
     def _filter_hetatm_records(
         self, exclude_water: bool = True, keep_resnames: Optional[list[str]] = None

--- a/src/drug_discovery/structures/protein.py
+++ b/src/drug_discovery/structures/protein.py
@@ -65,7 +65,6 @@ from deeporigin.drug_discovery.external_tools.utils import (
     get_protein_info_dict,
 )
 from deeporigin.exceptions import DeepOriginException
-from deeporigin.functions.pocket_finder import find_pockets
 
 from .entity import Entity
 from .ligand import Ligand, LigandSet
@@ -250,14 +249,14 @@ class Protein(Entity):
     def model_loops(self) -> None:
         """model loops in protein structure"""
 
-        from deeporigin.functions.loop_modelling import model_loops
+        from deeporigin.functions.loop_modelling import _model_loops
 
         pdb_id = self.pdb_id
 
         if pdb_id is None:
             raise ValueError("Currently, PDB ID is required to model loops.")
 
-        file_path = model_loops(pdb_id=pdb_id)
+        file_path = _model_loops(pdb_id=pdb_id)
         protein = Protein.from_file(file_path)
         self.structure = protein.structure
 
@@ -282,6 +281,7 @@ class Protein(Entity):
         Returns:
             str: Path to the SDF file containing the docked ligand structure.
         """
+        # Import here to avoid circular import
         from deeporigin.functions import docking
 
         docked_ligand_sdf_file = docking.dock(
@@ -484,8 +484,12 @@ class Protein(Entity):
             >>> for pocket in pockets:
             ...     print(f"Pocket: {pocket.name}, Volume: {pocket.properties.get('volume')} Å³")
         """
-        results_dir = find_pockets(
-            self.file_path,
+        # Import here to avoid circular import
+        # note that name is changed to avoid conflict with the function
+        from deeporigin.functions.pocket_finder import find_pockets as _find_pockets
+
+        results_dir = _find_pockets(
+            protein=self,
             pocket_count=pocket_count,
             pocket_min_size=pocket_min_size,
         )

--- a/src/functions/loop_modelling.py
+++ b/src/functions/loop_modelling.py
@@ -1,10 +1,11 @@
 """This module contains the function to run loop modelling on a protein identified by a PDB ID."""
 
-import hashlib
 import os
 
 from beartype import beartype
 import requests
+
+from deeporigin.utils.core import hash_dict
 
 URL = "http://loop-modelling.default.jobs.edge.deeporigin.io/model_loops"
 CACHE_DIR = os.path.expanduser("~/.deeporigin/model_loops")
@@ -25,20 +26,18 @@ def model_loops(
         Path to the output PDB file if successful, or raises RuntimeError if the server fails.
     """
 
-    # Create a hash of the input parameters for caching
-    hash_input = f"{pdb_id}"
-    cache_key = hashlib.md5(hash_input.encode()).hexdigest()
-    cache_path = os.path.join(CACHE_DIR, cache_key)
+    # If no cached results, proceed with server call
+    payload = {
+        "pdb_id": pdb_id,
+    }
+
+    cache_hash = hash_dict(payload)
+    cache_path = os.path.join(CACHE_DIR, cache_hash)
     output_pdb_path = os.path.join(cache_path, "loops_modelled.pdb")
 
     # Check if cached results exist
     if os.path.exists(output_pdb_path):
         return output_pdb_path
-
-    # If no cached results, proceed with server call
-    payload = {
-        "pdb_id": pdb_id,
-    }
 
     response = requests.post(URL, json=payload, stream=True)
 

--- a/src/functions/loop_modelling.py
+++ b/src/functions/loop_modelling.py
@@ -15,6 +15,7 @@ CACHE_DIR = os.path.expanduser("~/.deeporigin/model_loops")
 def model_loops(
     *,
     pdb_id: str,
+    use_cache: bool = True,
 ) -> str:
     """
     Run system preparation on a protein-ligand complex.
@@ -36,7 +37,7 @@ def model_loops(
     output_pdb_path = os.path.join(cache_path, "loops_modelled.pdb")
 
     # Check if cached results exist
-    if os.path.exists(output_pdb_path):
+    if use_cache and os.path.exists(output_pdb_path):
         return output_pdb_path
 
     response = requests.post(URL, json=payload, stream=True)

--- a/src/functions/molprops.py
+++ b/src/functions/molprops.py
@@ -2,13 +2,14 @@
 using the DeepOrigin API.
 """
 
-import hashlib
 import json
 import os
 from pathlib import Path
 
 from beartype import beartype
 import requests
+
+from deeporigin.utils.core import hash_dict
 
 URL = "http://molprops.default.jobs.edge.deeporigin.io/properties"
 CACHE_DIR = os.path.expanduser("~/.deeporigin/molprops")
@@ -34,10 +35,12 @@ def molprops(
         str: Path to the cached SDF file containing the results
     """
 
+    payload = {
+        "smiles": smiles_string,
+    }
+
     # Create hash of inputs
-    hasher = hashlib.sha256()
-    hasher.update(smiles_string.encode("utf-8"))
-    cache_hash = hasher.hexdigest()
+    cache_hash = hash_dict(payload)
     response_file = str(Path(CACHE_DIR) / f"{cache_hash}.json")
 
     # Check if cached result exists
@@ -48,17 +51,11 @@ def molprops(
 
     else:
         # Prepare the request payload
-        payload = {
-            "functionId": "molprops",
-            "params": {
-                "smiles": smiles_string,
-            },
-        }
 
         # Make the API request
         response = requests.post(
             URL,
-            json=payload["params"],
+            json=payload,
             headers={"Content-Type": "application/json"},
         )
 

--- a/src/functions/pocket_finder.py
+++ b/src/functions/pocket_finder.py
@@ -20,6 +20,7 @@ def find_pockets(
     protein: Protein,
     pocket_count: int = 5,
     pocket_min_size: int = 30,
+    use_cache: bool = True,
 ) -> str | None:
     """Find protein binding pockets in a PDB structure and save the results.
 
@@ -46,7 +47,7 @@ def find_pockets(
     cache_path = os.path.join(CACHE_DIR, cache_key)
 
     # Check if cached results exist
-    if os.path.exists(cache_path):
+    if use_cache and os.path.exists(cache_path):
         return cache_path
 
     # Send the request to the server

--- a/src/functions/sysprep.py
+++ b/src/functions/sysprep.py
@@ -13,7 +13,7 @@ CACHE_DIR = os.path.expanduser("~/.deeporigin/sysprep")
 
 
 @beartype
-def sysprep(
+def run_sysprep(
     *,
     protein: Protein,
     ligand: Ligand,

--- a/src/utils/core.py
+++ b/src/utils/core.py
@@ -178,6 +178,25 @@ def hash_file(file_path: str | Path) -> str:
 
 
 @beartype
+def hash_dict(data: dict) -> str:
+    """
+    Computes a SHA-256 hash for a dictionary.
+
+    Parameters:
+        data (dict): A dictionary.
+
+    Returns:
+        str: The hexadecimal SHA-256 hash of the dictionary.
+    """
+    sorted_keys = sorted(data.keys())
+    data = {key: data[key] for key in sorted_keys}
+
+    hasher = hashlib.sha256()
+    hasher.update(json.dumps(data).encode())
+    return hasher.hexdigest()
+
+
+@beartype
 def hash_strings(strings: list[str]) -> str:
     """
     Computes a SHA-256 hash for a list of strings in an order-insensitive manner.

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -55,14 +55,14 @@ def test_sysprep(config):  # noqa: F811
         pytest.skip("test skipped with mock client")
 
     from deeporigin.drug_discovery import BRD_DATA_DIR, Complex
-    from deeporigin.functions.sysprep import sysprep
+    from deeporigin.functions.sysprep import run_sysprep
 
     sim = Complex.from_dir(BRD_DATA_DIR)
 
     # this is chosen to be one where it takes >1 min
-    sysprep(
-        protein_path=sim.protein.file_path,
-        ligand_path=sim.ligands[3].file_path,
+    run_sysprep(
+        protein=sim.protein,
+        ligand=sim.ligands[3],
         is_lig_protonated=True,
     )
 

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -13,7 +13,7 @@ def test_molprops(config):  # noqa: F811
 
     ligand = Ligand.from_identifier("serotonin")
 
-    props = ligand.admet_properties()
+    props = ligand.admet_properties(use_cache=False)
 
     assert isinstance(props, dict), "Expected a dictionary"
     assert "logP" in props, "Expected logP to be in the properties"
@@ -27,7 +27,10 @@ def test_pocket_finder(config):  # noqa: F811
     from deeporigin.drug_discovery import Protein
 
     protein = Protein.from_pdb_id("1EBY")
-    pockets = protein.find_pockets(pocket_count=1)
+    pockets = protein.find_pockets(
+        pocket_count=1,
+        use_cache=False,
+    )
 
     assert len(pockets) == 1, "Incorrect number of pockets"
 
@@ -43,7 +46,11 @@ def test_docking(config):  # noqa: F811
 
     ligand = Ligand.from_smiles("CN(C)C(=O)c1cccc(-c2cn(C)c(=O)c3[nH]ccc23)c1")
 
-    poses_sdf = protein.dock(ligand=ligand, pocket=pocket)
+    poses_sdf = protein.dock(
+        ligand=ligand,
+        pocket=pocket,
+        use_cache=False,
+    )
 
     assert isinstance(poses_sdf, str), (
         "Expected a string to be returned by dock function"
@@ -64,6 +71,7 @@ def test_sysprep(config):  # noqa: F811
         protein=sim.protein,
         ligand=sim.ligands[3],
         is_lig_protonated=True,
+        use_cache=False,
     )
 
 
@@ -75,7 +83,7 @@ def test_loop_modelling(config):  # noqa: F811
 
     protein = Protein.from_pdb_id("5QSP")
     assert len(protein.find_missing_residues()) > 0, "Missing residues should be > 0"
-    protein.model_loops()
+    protein.model_loops(use_cache=False)
 
     assert protein.structure is not None, "Structure should not be None"
 
@@ -90,7 +98,7 @@ def test_konnektor(config):  # noqa: F811
 
     ligands = LigandSet.from_sdf(DATA_DIR / "ligands" / "ligands-brd-all.sdf")
 
-    ligands.map_network()
+    ligands.map_network(use_cache=False)
 
     assert len(ligands.network.keys()) > 0, "Expected network to be non-empty"
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,150 @@
+"""Tests for utility functions in the core module"""
+
+import hashlib
+import json
+
+from src.utils.core import hash_dict
+
+
+def test_basic_dict_hashing():
+    """Test that hash_dict produces a valid SHA-256 hash for a simple dictionary"""
+    test_dict = {"a": 1, "b": 2, "c": 3}
+    result = hash_dict(test_dict)
+
+    # Check that result is a string
+    assert isinstance(result, str)
+
+    # Check that result is a valid hex string (SHA-256 produces 64 hex characters)
+    assert len(result) == 64
+    assert all(c in "0123456789abcdef" for c in result)
+
+    # Verify the hash is deterministic
+    result2 = hash_dict(test_dict)
+    assert result == result2
+
+
+def test_dict_key_ordering():
+    """Test that hash_dict produces the same hash regardless of key order"""
+    dict1 = {"a": 1, "b": 2, "c": 3}
+    dict2 = {"c": 3, "a": 1, "b": 2}
+
+    hash1 = hash_dict(dict1)
+    hash2 = hash_dict(dict2)
+
+    assert hash1 == hash2
+
+
+def test_nested_dict_hashing():
+    """Test that hash_dict works with nested dictionaries"""
+    test_dict = {
+        "outer": {"inner": {"deep": "value"}, "list": [1, 2, 3]},
+        "simple": "string",
+    }
+
+    result = hash_dict(test_dict)
+    assert isinstance(result, str)
+    assert len(result) == 64
+
+
+def test_empty_dict():
+    """Test that hash_dict works with an empty dictionary"""
+    result = hash_dict({})
+    assert isinstance(result, str)
+    assert len(result) == 64
+
+    # Empty dict should always produce the same hash
+    result2 = hash_dict({})
+    assert result == result2
+
+
+def test_dict_with_different_value_types():
+    """Test that hash_dict works with various value types"""
+    test_dict = {
+        "string": "hello",
+        "integer": 42,
+        "float": 3.14,
+        "boolean": True,
+        "none": None,
+        "list": [1, 2, 3],
+        "dict": {"nested": "value"},
+    }
+
+    result = hash_dict(test_dict)
+    assert isinstance(result, str)
+    assert len(result) == 64
+
+
+def test_manual_hash_verification():
+    """Test that the hash matches what we would expect from manual calculation"""
+    test_dict = {"a": 1, "b": 2}
+
+    # Manual calculation of expected hash
+    sorted_keys = sorted(test_dict.keys())
+    sorted_dict = {key: test_dict[key] for key in sorted_keys}
+    expected_hash = hashlib.sha256(json.dumps(sorted_dict).encode()).hexdigest()
+
+    actual_hash = hash_dict(test_dict)
+    assert actual_hash == expected_hash
+
+
+def test_unicode_strings():
+    """Test that hash_dict works with unicode strings"""
+    test_dict = {"english": "hello", "unicode": "こんにちは", "emoji": "🚀"}
+
+    result = hash_dict(test_dict)
+    assert isinstance(result, str)
+    assert len(result) == 64
+
+
+def test_large_dict():
+    """Test that hash_dict works with larger dictionaries"""
+    test_dict = {f"key_{i}": f"value_{i}" for i in range(100)}
+
+    result = hash_dict(test_dict)
+    assert isinstance(result, str)
+    assert len(result) == 64
+
+
+def test_dict_with_special_characters():
+    """Test that hash_dict works with special characters in keys and values"""
+    test_dict = {
+        "key with spaces": "value with spaces",
+        "key-with-dashes": "value-with-dashes",
+        "key_with_underscores": "value_with_underscores",
+        "key.with.dots": "value.with.dots",
+        "key:with:colons": "value:with:colons",
+        "key/with/slashes": "value/with/slashes",
+    }
+
+    result = hash_dict(test_dict)
+    assert isinstance(result, str)
+    assert len(result) == 64
+
+
+def test_consistency_across_runs():
+    """Test that the same dictionary always produces the same hash across multiple runs"""
+    test_dict = {"test": "data", "numbers": [1, 2, 3, 4, 5]}
+
+    hashes = []
+    for _ in range(10):
+        hashes.append(hash_dict(test_dict))
+
+    # All hashes should be identical
+    assert len(set(hashes)) == 1
+    assert hashes[0] == hash_dict(test_dict)
+
+
+def test_different_dicts_produce_different_hashes():
+    """Test that different dictionaries produce different hashes"""
+    dict1 = {"a": 1, "b": 2}
+    dict2 = {"a": 1, "b": 3}
+    dict3 = {"a": 1, "c": 2}
+
+    hash1 = hash_dict(dict1)
+    hash2 = hash_dict(dict2)
+    hash3 = hash_dict(dict3)
+
+    # All hashes should be different
+    assert hash1 != hash2
+    assert hash1 != hash3
+    assert hash2 != hash3


### PR DESCRIPTION
## changes

- [x] all functions use a common function to hash payloads
- [x] eliminated some redundant base64 conversion code
- [x] fixed tests -- they were broken by recent platform refactor when using live client
- [x] all methods and functions support `use_cache`