### PR TITLE
fix: back to dual template design

### DIFF
--- a/src/tools/job.py
+++ b/src/tools/job.py
@@ -183,8 +183,15 @@ class Job:
         using the visualization function if set, or a default HTML representation.
         """
 
-        # Use a single Shadow DOM-based template to avoid CSS/JS conflicts across environments
-        template = env.get_template("job_widget.html")
+        from deeporigin.utils.notebook import get_notebook_environment
+
+        if get_notebook_environment() == "jupyter":
+            # this template uses shadow DOM to avoid CSS/JS conflicts with jupyter
+            # however, for reasons i don't understand, it doesn't work in marimo/browser
+            template = env.get_template("job_widget.html")
+        else:
+            # this one is more straightforward, and works in marimo/browser
+            template = env.get_template("job.html")
 
         try:
             status_html = self._viz_func(self)
@@ -420,7 +427,7 @@ class Job:
 
 
 # @beartype
-def get_dataframe(
+def get_dataframe(  #
     *,
     tool_key: Optional[str] = None,
     only_with_status: Optional[list[str] | set[str]] = None,


### PR DESCRIPTION
## changes

my unified job widget html worked nicely in jupyter, but didn't work anywhere else.

falling back to the two-template design for now