### PR TITLE
fix(QA-566): add support for new and legacy system_prep output

### DIFF
--- a/src/drug_discovery/abfe.py
+++ b/src/drug_discovery/abfe.py
@@ -351,14 +351,26 @@ class ABFE(WorkflowStep):
             try:
                 prepared_system = self.parent._prepared_systems[ligand.to_hash()]
 
-                output_files = prepared_system["output_files"]
+                # Support system-prep output format: system dict with file paths
+                system = prepared_system.get("system", {})
+                if system:
+                    binding_xml = system.get("binding_xml_file_path")
+                    solvation_xml = system.get("solvation_xml_file_path")
+                else:
+                    # Legacy: output_files list
+                    output_files = prepared_system["output_files"]
+                    binding_xml = next(
+                        f for f in output_files if f.endswith("bsm_system.xml")
+                    )
+                    solvation_xml = next(
+                        f for f in output_files if f.endswith("solvation.xml")
+                    )
 
-                binding_xml = [
-                    file for file in output_files if file.endswith("bsm_system.xml")
-                ][0]
-                solvation_xml = [
-                    file for file in output_files if file.endswith("solvation.xml")
-                ][0]
+                if not binding_xml or not solvation_xml:
+                    raise KeyError(
+                        "Prepared system missing binding_xml_file_path or "
+                        "solvation_xml_file_path in system"
+                    )
 
                 params = self._params["end_to_end"]
 


### PR DESCRIPTION
Before:
```
uv run tests/run_abfe.py
Preparing system...
✅ System prepared
Traceback (most recent call last):
  File "/Users/tiago/projects/do-dd-client/src/drug_discovery/abfe.py", line 354, in run
    output_files = prepared_system["output_files"]
                   ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^
KeyError: 'output_files'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/tiago/projects/do-dd-client/tests/run_abfe.py", line 54, in <module>
    run_abfe()
    ~~~~~~~~^^
  File "/Users/tiago/projects/do-dd-client/tests/run_abfe.py", line 22, in run_abfe
    jobs = sim.abfe.run(ligands=[ligand], quote=True, output_dir_path=output_dir_path)
  File "<@beartype(deeporigin.drug_discovery.abfe.ABFE.run) at 0x118b79940>", line 131, in run
  File "/Users/tiago/projects/do-dd-client/src/drug_discovery/abfe.py", line 375, in run
    raise DeepOriginException(
        "There is an error with the prepared system. Please prepare the system using the `prepare` method of Complex."
    ) from e
deeporigin.exceptions.DeepOriginException: ╔═ There is an error with the prepared system. Please prepare the system using the `prepare` method of Complex. ═╗
```

After:

```
uv run tests/run_abfe.py
Preparing system...
✅ System prepared
⚠️ Warning: test_run=1 in these parameters. Results and quoted prices will not be accurate.
✅ Job quoted
89e474e7-1afd-4d40-8484-820277dbaaab
```

Running it from pybridge (stress test), was failing for the same reason:

```
pnpm test:e2e:lv3:dev -- apps/platform-e2e/src/specs/do-client/tools.spec.ts

> @deeporigin/source@1.0.0 test:e2e:lv3:dev /Users/tiago/projects/platform
> nx run platform-e2e:e2e-lvl3:dev --output=test-results --skip-nx-cache -- apps/platform-e2e/src/specs/do-client/tools.spec.ts


> nx run platform-e2e:e2e-lvl3:dev apps/platform-e2e/src/specs/do-client/tools.spec.ts

npm warn Unknown env config "_biosim-ai-registry". This will stop working in the next major version of npm.
{
  message: '[repo] repoUrl',
  repoUrl: 'https://github.com/deeporiginbio/do-dd-client',
  branch: 'main'
}

Running 1 test using 1 worker

{
  message: '[repo] repoUrl',
  repoUrl: 'https://github.com/deeporiginbio/do-dd-client',
  branch: 'main'
}
     1 [e2e] › src/specs/do-client/tools.spec.ts:138:8 › ABFE and Bulk Docking end-to-end flow › @lv3-reg ABFE quote, confirm, wait for finish, compare prices
{
  message: '[repo] Using cached deeporigin-client',
  commitSha: '28420f0ff2979d9c653025ab719d253ba7b0a1bc'
}
Python 3.12 is already installed
{ message: '[venv] Skipping make install (already set up)' }
{ message: '[venv] Python', version: 'Python 3.13.11' }
{ message: '[venv] Verifying imports: deeporigin, yaml' }
Python 3.12 is already installed
{ message: '[venv] Skipping make install (already set up)' }
{ message: '[venv] Python', version: 'Python 3.13.11' }
{ message: '[venv] Verifying imports: deeporigin, yaml' }
{
  message: '[executeJob] Starting job',
  jobId: 'a824d12f-c111-4a41-80f2-48d305157788',
  tool: 'abfe'
}
{
  message: '[local-auth] Fetching Keycloak token',
  url: 'https://login.dev.deeporigin.io/realms/deeporigin/protocol/openid-connect/token'
}
{
  message: '[pybridge] Injected Keycloak token and org key',
  targetEnv: 'dev'
}
{
  message: '[process] Spawned',
  pythonPath: '/Users/tiago/.pybridge/deeporigin-client/.venv/bin/python',
  cmd: 'src/libs/pybridge/tool-runners/abfe.py --ligandIndex 0 --useTestRun True --reRun False --orgKey deeporigin --action quote',
  pid: 9780
}
{
  message: '[process] Exited',
  cmd: 'src/libs/pybridge/tool-runners/abfe.py --ligandIndex 0 --useTestRun True --reRun False --orgKey deeporigin --action quote',
  pid: 9780,
  code: 1,
  signal: null
}
{
  message: '[runTool] run failed',
  toolKey: 'abfe',
  args: [ '--action', 'quote' ],
  result: {
    exitCode: 1,
    stdout: '',
    stderr: 'Traceback (most recent call last):\n' +
      '  File \x1B[35m"/Users/tiago/.pybridge/deeporigin-client/src/drug_discovery/abfe.py"\x1B[0m, line \x1B[35m354\x1B[0m, in \x1B[35mrun\x1B[0m\n' +
      '    output_files = \x1B[31mprepared_system\x1B[0m\x1B[1;31m["output_files"]\x1B[0m\n' +
      '                   \x1B[31m~~~~~~~~~~~~~~~\x1B[0m\x1B[1;31m^^^^^^^^^^^^^^^^\x1B[0m\n' +
      "\x1B[1;35mKeyError\x1B[0m: \x1B[35m'output_files'\x1B[0m\n" +
      '\n' +
      'The above exception was the direct cause of the following exception:\n' +
      '\n' +
      'Traceback (most recent call last):\n' +
      '  File \x1B[35m"/Users/tiago/projects/platform/apps/platform-e2e/src/libs/pybridge/tool-runners/abfe.py"\x1B[0m, line \x1B[35m102\x1B[0m, in \x1B[35m<module>\x1B[0m\n' +
      '    \x1B[31mmain\x1B[0m\x1B[1;31m()\x1B[0m\n' +
      '    \x1B[31m~~~~\x1B[0m\x1B[1;31m^^\x1B[0m\n' +
      '  File \x1B[35m"/Users/tiago/projects/platform/apps/platform-e2e/src/libs/pybridge/tool-runners/abfe.py"\x1B[0m, line \x1B[35m84\x1B[0m, in \x1B[35mmain\x1B[0m\n' +
      '    result = do_run(args.action, args.ligandIndex, args.useTestRun)\n' +
      '  File \x1B[35m"/Users/tiago/projects/platform/apps/platform-e2e/src/libs/pybridge/tool-runners/abfe.py"\x1B[0m, line \x1B[35m19\x1B[0m, in \x1B[35mdo_run\x1B[0m\n' +
      '    jobs = sim.abfe.run(ligand=target_ligand, quote=True)\n' +
      '  File \x1B[35m"<@beartype(deeporigin.drug_discovery.abfe.ABFE.run) at 0x12400d120>"\x1B[0m, line \x1B[35m131\x1B[0m, in \x1B[35mrun\x1B[0m\n' +
      '  File \x1B[35m"/Users/tiago/.pybridge/deeporigin-client/src/drug_discovery/abfe.py"\x1B[0m, line \x1B[35m375\x1B[0m, in \x1B[35mrun\x1B[0m\n' +
      '    raise DeepOriginException(\n' +
      '        "There is an error with the prepared system. Please prepare the system using the `prepare` method of Complex."\n' +
      '    ) from e\n' +
      '\x1B[1;35mdeeporigin.exceptions.DeepOriginException\x1B[0m: \x1B[35m╔═ There is an error with the prepared system. Please prepare the system using the `prepare` method of Complex. ═╗\x1B[0m\n'
  }
}
```