### PR TITLE
feat: add Datasets API wrapper for data platform admin endpoints

### DIFF
--- a/src/platform/client.py
+++ b/src/platform/client.py
@@ -50,6 +50,7 @@ from deeporigin.utils.env import _ensure_do_folder
 if TYPE_CHECKING:
     from deeporigin.platform.billing import Billing
     from deeporigin.platform.clusters import Clusters
+    from deeporigin.platform.datasets import Datasets
     from deeporigin.platform.entities import Entities
     from deeporigin.platform.executions import Executions
     from deeporigin.platform.files import Files
@@ -286,6 +287,7 @@ class DeepOriginClient(metaclass=_DeepOriginMeta):
     tools: Tools | None
     functions: Functions | None
     clusters: Clusters | None
+    datasets: Datasets | None
     files: Files | None
     executions: Executions | None
     organizations: Organizations | None
@@ -435,6 +437,13 @@ class DeepOriginClient(metaclass=_DeepOriginMeta):
             self.projects = Projects(self)
         except ImportError:
             self.projects = None
+
+        try:
+            from deeporigin.platform.datasets import Datasets
+
+            self.datasets = Datasets(self)
+        except ImportError:
+            self.datasets = None
 
         self.max_retries = max_retries
         self.retryable_status_codes = HTTP_RETRYABLE_STATUS_CODES

--- a/src/platform/datasets.py
+++ b/src/platform/datasets.py
@@ -1,0 +1,247 @@
+"""Data Platform dataset API wrapper (admin-scoped CRUD, search, and import trigger)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from deeporigin.auth import decode_access_token
+from deeporigin.exceptions import DeepOriginException
+
+if TYPE_CHECKING:
+    from deeporigin.platform.client import DeepOriginClient
+
+ADMIN_PREFIX = "/data-platform/admin"
+_SUPERUSER_REALM_ROLE = "do-super-user"
+
+
+class Datasets:
+    """Dataset API wrapper.
+
+    Provides access to dataset CRUD, search, and import-trigger endpoints
+    through the DeepOriginClient. All endpoints require SUPERUSER scope.
+    """
+
+    def __init__(self, client: DeepOriginClient) -> None:
+        self._c = client
+
+    def _require_superuser(self) -> None:
+        """Verify the client token carries the ``do-super-user`` realm role.
+
+        Skipped for local environments (mock server, no real auth).
+
+        Raises:
+            DeepOriginException: If the token lacks the SUPERUSER role.
+        """
+        if self._c.env == "local":
+            return
+        claims = decode_access_token(self._c.token)
+        roles: list[str] = claims.get("realm_access", {}).get("roles", [])
+        if _SUPERUSER_REALM_ROLE not in roles:
+            raise DeepOriginException(
+                title="Insufficient Scope",
+                message=(
+                    "Dataset admin endpoints require the SUPERUSER role "
+                    f"('{_SUPERUSER_REALM_ROLE}' in realm_access.roles). "
+                    "Your current token does not have this role."
+                ),
+            )
+
+    def search(
+        self,
+        *,
+        cursor: str | None = None,
+        filter_dict: dict[str, Any] | None = None,
+        limit: int | None = None,
+        offset: int | None = None,
+        select: list[str] | None = None,
+        sort: dict[str, str] | None = None,
+        search: str | None = None,
+        with_total_count: bool = False,
+    ) -> dict:
+        """Search datasets.
+
+        Args:
+            cursor: Keyset pagination cursor.
+            filter_dict: Filter criteria (e.g. ``{"tags": {"in": ["HTS", "FBDD"]}}``).
+            limit: Maximum number of results per page.
+            offset: Number of results to skip.
+            select: Fields to include in the response.
+            sort: Sort specification (e.g. ``{"name": "asc"}``).
+            search: Free-text search across fulltext-indexed fields (name, summary).
+            with_total_count: If True, return only ``meta.total_count`` (no rows).
+
+        Returns:
+            Dictionary with ``data`` (list of datasets) and ``meta``.
+        """
+        self._require_superuser()
+        body: dict[str, Any] = {}
+        if cursor is not None:
+            body["cursor"] = cursor
+        if filter_dict is not None:
+            body["filter"] = filter_dict
+        if limit is not None:
+            body["limit"] = limit
+        if offset is not None:
+            body["offset"] = offset
+        if select is not None:
+            body["select"] = select
+        if sort is not None:
+            body["sort"] = sort
+        if search is not None:
+            body["search"] = search
+        if with_total_count:
+            body["with_total_count"] = True
+
+        return self._c.post_json(f"{ADMIN_PREFIX}/datasets/search", body=body)
+
+    def get(self, id: str) -> dict:
+        """Get a dataset by ID.
+
+        Args:
+            id: Dataset ID (friendly or 16 hex chars).
+
+        Returns:
+            Dictionary containing the dataset record.
+        """
+        self._require_superuser()
+        return self._c.get_json(f"{ADMIN_PREFIX}/datasets/{id}")
+
+    def create(
+        self,
+        *,
+        name: str,
+        file_path: str,
+        dataset_key: str,
+        dataset_version: str,
+        summary: str | None = None,
+        description: str | None = None,
+        source_url: str | None = None,
+        source_name: str | None = None,
+        tags: list[str] | None = None,
+        compound_count: int | None = None,
+        file_size_bytes: int | None = None,
+        dataset_schema: dict[str, Any] | None = None,
+        sample_rows: list[dict[str, Any]] | None = None,
+        changelog: str | None = None,
+    ) -> dict:
+        """Create a dataset record.
+
+        Args:
+            name: Dataset display name (required).
+            file_path: Resolved storage path in file-service (required).
+            dataset_key: Routing key for catalog resolution (required).
+            dataset_version: Routing version for catalog resolution (required).
+            summary: Short blurb for card subtitle.
+            description: Full detail text.
+            source_url: Link to original data source.
+            source_name: Display label for the external source link.
+            tags: List of tag strings.
+            compound_count: Total number of compounds/rows.
+            file_size_bytes: Size of the dataset file in bytes.
+            dataset_schema: JSON Schema with x-* extensions describing import structure.
+            sample_rows: Cached first rows for preview.
+            changelog: Description of what changed in this version.
+
+        Returns:
+            Dictionary containing the created dataset record.
+        """
+        self._require_superuser()
+        set_dict: dict[str, Any] = {
+            "name": name,
+            "file_path": file_path,
+            "dataset_key": dataset_key,
+            "dataset_version": dataset_version,
+        }
+        if summary is not None:
+            set_dict["summary"] = summary
+        if description is not None:
+            set_dict["description"] = description
+        if source_url is not None:
+            set_dict["source_url"] = source_url
+        if source_name is not None:
+            set_dict["source_name"] = source_name
+        if tags is not None:
+            set_dict["tags"] = tags
+        if compound_count is not None:
+            set_dict["compound_count"] = compound_count
+        if file_size_bytes is not None:
+            set_dict["file_size_bytes"] = file_size_bytes
+        if dataset_schema is not None:
+            set_dict["dataset_schema"] = dataset_schema
+        if sample_rows is not None:
+            set_dict["sample_rows"] = sample_rows
+        if changelog is not None:
+            set_dict["changelog"] = changelog
+
+        return self._c.post_json(
+            f"{ADMIN_PREFIX}/datasets",
+            body={"set": set_dict},
+        )
+
+    def update(self, id: str, *, set_dict: dict[str, Any]) -> dict:
+        """Update a dataset record.
+
+        Args:
+            id: Dataset ID (friendly or 16 hex chars).
+            set_dict: Fields to update (e.g. ``{"description": "new text"}``).
+
+        Returns:
+            Dictionary containing the updated dataset record.
+        """
+        self._require_superuser()
+        return self._c._patch(
+            f"{ADMIN_PREFIX}/datasets/{id}",
+            json={"set": set_dict},
+        ).json()
+
+    def trigger_import(
+        self,
+        id: str,
+        *,
+        org_key: str,
+        cluster_id: str,
+        batch_size: int | None = None,
+        dry_run: bool | None = None,
+        max_rows: int | None = None,
+        name: str | None = None,
+        project_id: str | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> dict:
+        """Trigger a dataset import into a target org.
+
+        Args:
+            id: Dataset ID to import.
+            org_key: Target organization key.
+            cluster_id: Compute cluster identifier (passed through to tools-service).
+            batch_size: Number of rows per MQ batch.
+            dry_run: If True, validate without writing data.
+            max_rows: Maximum number of rows to import.
+            name: Execution display name.
+            project_id: Target project ID.
+            metadata: Additional metadata passed to the import tool.
+
+        Returns:
+            Dictionary with ``executionId`` of the triggered import.
+        """
+        self._require_superuser()
+        body: dict[str, Any] = {
+            "orgKey": org_key,
+            "clusterId": cluster_id,
+        }
+        if batch_size is not None:
+            body["batchSize"] = batch_size
+        if dry_run is not None:
+            body["dryRun"] = dry_run
+        if max_rows is not None:
+            body["maxRows"] = max_rows
+        if name is not None:
+            body["name"] = name
+        if project_id is not None:
+            body["projectId"] = project_id
+        if metadata is not None:
+            body["metadata"] = metadata
+
+        return self._c.post_json(
+            f"{ADMIN_PREFIX}/datasets/{id}/import",
+            body=body,
+        )

--- a/tests/mock_server/routers/data_platform.py
+++ b/tests/mock_server/routers/data_platform.py
@@ -338,6 +338,7 @@ def create_data_platform_router(
     projects: dict[str, dict[str, Any]],
     results: list[dict[str, Any]],
     executions: dict[str, dict[str, Any]] | None = None,
+    datasets: dict[str, dict[str, Any]] | None = None,
     load_fixture: Callable[[str], dict[str, Any]],
 ) -> APIRouter:
     """Create a router for data-platform endpoints.
@@ -348,12 +349,15 @@ def create_data_platform_router(
         projects: In-memory storage for data platform projects.
         results: In-memory list of result-explorer records.
         executions: In-memory storage for executions (keyed by executionId).
+        datasets: In-memory storage for datasets (keyed by dataset ID).
         load_fixture: Callable to load fixture data by name.
 
     Returns:
         APIRouter instance with data-platform routes.
     """
     router = APIRouter()
+
+    _datasets: dict[str, dict[str, Any]] = datasets if datasets is not None else {}
 
     _entity_stores: dict[str, dict[str, dict[str, Any]]] = {
         "ligands": ligands,
@@ -499,6 +503,113 @@ def create_data_platform_router(
         if with_history:
             response["with_history"] = True
         return response
+
+    # ---- Admin dataset endpoints (registered before catch-all entity routes) ----
+
+    @router.post("/data-platform/admin/datasets/search")
+    async def admin_search_datasets(request: Request) -> dict[str, Any]:
+        """Search datasets (admin)."""
+        body = await request.json()
+        filter_dict = body.get("filter", {})
+        limit = body.get("limit", 100)
+        offset = body.get("offset", 0)
+        search_term = body.get("search")
+
+        results_list = list(_datasets.values())
+
+        if search_term:
+            term = search_term.lower()
+            results_list = [
+                r
+                for r in results_list
+                if term in (r.get("name") or "").lower()
+                or term in (r.get("summary") or "").lower()
+                or term in (r.get("description") or "").lower()
+            ]
+
+        for key, value in filter_dict.items():
+            if isinstance(value, dict) and "in" in value:
+                allowed = value["in"]
+                results_list = [
+                    r
+                    for r in results_list
+                    if isinstance(r.get(key), list)
+                    and all(t in r[key] for t in allowed)
+                ]
+            elif isinstance(value, dict) and "eq" in value:
+                results_list = [r for r in results_list if r.get(key) == value["eq"]]
+            elif not isinstance(value, dict):
+                results_list = [r for r in results_list if r.get(key) == value]
+
+        total = len(results_list)
+
+        if body.get("with_total_count"):
+            return {"data": [], "meta": {"count": 0, "limit": 0, "total_count": total}}
+
+        page = results_list[offset : offset + limit]
+        return {"data": page, "meta": {"count": total, "limit": limit}}
+
+    @router.get("/data-platform/admin/datasets/{dataset_id}")
+    def admin_get_dataset(dataset_id: str) -> dict[str, Any]:
+        """Get a dataset by ID (admin)."""
+        from fastapi import HTTPException
+
+        if dataset_id not in _datasets:
+            raise HTTPException(
+                status_code=404, detail=f"Dataset {dataset_id} not found"
+            )
+        return {"data": _datasets[dataset_id]}
+
+    @router.post("/data-platform/admin/datasets")
+    async def admin_create_dataset(request: Request) -> dict[str, Any]:
+        """Create a dataset (admin)."""
+        body = await request.json()
+        set_data = body.get("set", {})
+        did = "ds-" + str(uuid.uuid4()).replace("-", "")[:12]
+        now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"
+        record: dict[str, Any] = {
+            "id": did,
+            "version": 1,
+            "valid_from": now,
+            "valid_to": None,
+            "modified_by": "mock-server",
+            "deleted": False,
+            **set_data,
+        }
+        _datasets[did] = record
+        return {"data": record, "meta": {"inserted": 1}}
+
+    @router.patch("/data-platform/admin/datasets/{dataset_id}")
+    async def admin_update_dataset(dataset_id: str, request: Request) -> dict[str, Any]:
+        """Update a dataset (admin)."""
+        from fastapi import HTTPException
+
+        if dataset_id not in _datasets:
+            raise HTTPException(
+                status_code=404, detail=f"Dataset {dataset_id} not found"
+            )
+        body = await request.json()
+        set_data = body.get("set", {})
+        _datasets[dataset_id].update(set_data)
+        return {"data": _datasets[dataset_id], "meta": {"affected": 1}}
+
+    @router.post("/data-platform/admin/datasets/{dataset_id}/import")
+    async def admin_trigger_import(dataset_id: str, request: Request) -> dict[str, Any]:
+        """Trigger a dataset import (admin)."""
+        from fastapi import HTTPException
+
+        if dataset_id not in _datasets:
+            raise HTTPException(
+                status_code=404, detail=f"Dataset {dataset_id} not found"
+            )
+        body = await request.json()
+        if not body.get("orgKey") or not body.get("clusterId"):
+            raise HTTPException(
+                status_code=400, detail="orgKey and clusterId are required"
+            )
+        return {"executionId": f"exec-{uuid.uuid4().hex[:12]}"}
+
+    # ---- Generic entity search (catch-all, must come after static routes) ----
 
     @router.post("/data-platform/{org_key}/{entity}/search")
     async def search_entity(

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1,0 +1,138 @@
+"""Tests for the Datasets API wrapper."""
+
+from deeporigin.platform import DeepOriginClient
+
+
+def test_create_dataset():
+    """Create a dataset and verify the response shape."""
+    client = DeepOriginClient()
+    result = client.datasets.create(
+        name="Test Dataset",
+        file_path="/datasets/test/data.csv",
+        dataset_key="test.dataset",
+        dataset_version="1.0.0",
+        summary="A test dataset",
+        tags=["HTS", "FBDD"],
+    )
+    assert "data" in result
+    assert result["data"]["name"] == "Test Dataset"
+    assert result["data"]["dataset_key"] == "test.dataset"
+    assert result["data"]["tags"] == ["HTS", "FBDD"]
+
+
+def test_search_datasets():
+    """Search datasets returns results."""
+    client = DeepOriginClient()
+    client.datasets.create(
+        name="Search Target",
+        file_path="/datasets/search/data.csv",
+        dataset_key="test.searchable",
+        dataset_version="1.0.0",
+    )
+    result = client.datasets.search()
+    assert "data" in result
+    assert isinstance(result["data"], list)
+    assert len(result["data"]) > 0
+
+
+def test_search_datasets_with_text_search():
+    """Search datasets using the fulltext search parameter."""
+    client = DeepOriginClient()
+    client.datasets.create(
+        name="Kinase Inhibitors",
+        file_path="/datasets/kinase/data.csv",
+        dataset_key="test.kinase",
+        dataset_version="1.0.0",
+        summary="EGFR kinase inhibitor screening data",
+    )
+    result = client.datasets.search(search="kinase")
+    assert "data" in result
+    assert len(result["data"]) > 0
+    names = [d["name"] for d in result["data"]]
+    assert any("Kinase" in n for n in names)
+
+
+def test_search_datasets_with_total_count():
+    """with_total_count returns meta.total_count and no data rows."""
+    client = DeepOriginClient()
+    client.datasets.create(
+        name="Count Target",
+        file_path="/datasets/count/data.csv",
+        dataset_key="test.countable",
+        dataset_version="1.0.0",
+    )
+    result = client.datasets.search(with_total_count=True)
+    assert result["data"] == []
+    assert "total_count" in result["meta"]
+    assert result["meta"]["total_count"] > 0
+
+
+def test_search_datasets_with_tag_filter():
+    """Search datasets filtered by tags (AND semantics)."""
+    client = DeepOriginClient()
+    client.datasets.create(
+        name="Tagged Dataset",
+        file_path="/datasets/tagged/data.csv",
+        dataset_key="test.tagged",
+        dataset_version="1.0.0",
+        tags=["HTS", "FBDD", "Kinase"],
+    )
+    result = client.datasets.search(filter_dict={"tags": {"in": ["HTS", "FBDD"]}})
+    assert "data" in result
+    assert len(result["data"]) > 0
+    for ds in result["data"]:
+        if ds.get("tags"):
+            assert "HTS" in ds["tags"]
+            assert "FBDD" in ds["tags"]
+
+
+def test_get_dataset():
+    """Get a dataset by ID."""
+    client = DeepOriginClient()
+    created = client.datasets.create(
+        name="Get Target",
+        file_path="/datasets/get/data.csv",
+        dataset_key="test.gettable",
+        dataset_version="1.0.0",
+    )
+    dataset_id = created["data"]["id"]
+    result = client.datasets.get(dataset_id)
+    assert "data" in result
+    assert result["data"]["id"] == dataset_id
+    assert result["data"]["name"] == "Get Target"
+
+
+def test_update_dataset():
+    """Update a dataset record."""
+    client = DeepOriginClient()
+    created = client.datasets.create(
+        name="Update Target",
+        file_path="/datasets/update/data.csv",
+        dataset_key="test.updatable",
+        dataset_version="1.0.0",
+    )
+    dataset_id = created["data"]["id"]
+    result = client.datasets.update(dataset_id, set_dict={"description": "Updated"})
+    assert "data" in result
+    assert result["data"]["description"] == "Updated"
+
+
+def test_trigger_import():
+    """Trigger an import and verify executionId is returned."""
+    client = DeepOriginClient()
+    created = client.datasets.create(
+        name="Import Target",
+        file_path="/datasets/import/data.csv",
+        dataset_key="test.importable",
+        dataset_version="1.0.0",
+        dataset_schema={"type": "object", "properties": {}},
+    )
+    dataset_id = created["data"]["id"]
+    result = client.datasets.trigger_import(
+        dataset_id,
+        org_key="test-org",
+        cluster_id="cluster-1",
+        batch_size=500,
+    )
+    assert "executionId" in result
+    assert result["executionId"].startswith("exec-")


### PR DESCRIPTION
## Summary

- Adds `Datasets` class in `src/platform/datasets.py` exposing the new data platform admin dataset endpoints: search (with fulltext + JSONB tag filtering), get, create, update, and trigger-import
- Wires `client.datasets` into `DeepOriginClient` following the existing lazy-import pattern
- Adds corresponding mock server routes and 7 tests covering all operations

Companion to [platform#DDOS-4974](https://github.com/deeporiginbio/platform/pulls) which adds the backend dataset import pipeline to `data-platform-service`.

## Endpoints covered

| Method | Route | Python method |
|--------|-------|---------------|
| `POST` | `/data-platform/admin/datasets/search` | `client.datasets.search(...)` |
| `GET` | `/data-platform/admin/datasets/:id` | `client.datasets.get(id)` |
| `POST` | `/data-platform/admin/datasets` | `client.datasets.create(...)` |
| `PATCH` | `/data-platform/admin/datasets/:id` | `client.datasets.update(id, set_dict=...)` |
| `POST` | `/data-platform/admin/datasets/:id/import` | `client.datasets.trigger_import(id, org_key=..., cluster_id=...)` |

## Test plan

- [x] All 7 new tests pass (`pytest tests/test_datasets.py --env local`)
- [x] Full suite passes (570 passed, 0 failed)
- [x] No changes to existing mock routes or tests

Made with [Cursor](https://cursor.com)