### PR TITLE
DDOS-5196: fix: handle null quotationResult in from_dto

### DIFF
--- a/src/drug_discovery/execution_mixins.py
+++ b/src/drug_discovery/execution_mixins.py
@@ -336,7 +336,7 @@ class AsyncExecutableMixin:
         instance._execution_dto = dto
         instance._name = dto.get("name")
 
-        quotation = dto.get("quotationResult", {})
+        quotation = dto.get("quotationResult") or {}
         successful = quotation.get("successfulQuotations", [])
         if successful:
             price = successful[0].get("priceTotal")


### PR DESCRIPTION
When `quotationResult` is present in the DTO but set to `null`, `dto.get("quotationResult", {})` returns `None` instead of `{}`, causing an `AttributeError` on the subsequent `.get()` call. Changed to `or {}` so a `None` value is also treated as an empty dict, making missing or null quotation data non-fatal.