### PR TITLE
ci: (QA-650-2) publish sdk html and junit live test artifacts

### DIFF
--- a/.github/workflows/live_tests.yml
+++ b/.github/workflows/live_tests.yml
@@ -96,4 +96,17 @@ jobs:
       - name: "Running tests against a live instance"
         env:
           TARGET_ENV: ${{ matrix.env }}
-        run: uv run pytest --env "$TARGET_ENV" -k "$TEST_LEVEL"
+        run: |
+          uv run pytest --env "$TARGET_ENV" -k "$TEST_LEVEL" \
+            --junitxml=sdk-test-results.xml \
+            --html=sdk-report.html --self-contained-html
+
+      - name: Upload SDK test artifacts
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: sdk-test-results-${{ matrix.env }}-${{ github.run_id }}-${{ github.run_attempt }}
+          if-no-files-found: warn
+          path: |
+            sdk-report.html
+            sdk-test-results.xml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ core = [
 lint = ["ruff"]
 test = [
     "pytest",
+    "pytest-html",
     "parameterized",
     "coverage",
     "interrogate",


### PR DESCRIPTION
- Add `pytest-html` to test optional dependencies so CI can generate HTML reports.
- Update live tests workflow to emit SDK JUnit + self-contained HTML outputs.
- Upload SDK test artifacts for downstream qa-toolkit aggregation and Slack reporting.