### PR TITLE
Provide projectId in bulk-docking body.

### DIFF
--- a/src/platform/executions.py
+++ b/src/platform/executions.py
@@ -55,6 +55,8 @@ class Executions:
 
         if "clusterId" not in payload:
             payload["clusterId"] = self._c.clusters.get_default_cluster_id()
+        if self._c.project_id is not None:
+            payload["projectId"] = self._c.project_id
 
         payload["app"] = self._c._app
         payload["session"] = self._c._session


### PR DESCRIPTION
This pull request introduces a small improvement to the `create` method in `src/platform/executions.py` by ensuring that the `projectId` is included in the payload if it is available. This helps maintain consistency and ensures that the execution is correctly associated with the current project.