### PR TITLE
fix: (QA-650) make workflow_call lv2 sdk tests cumulative

### DIFF
--- a/.github/workflows/live_tests.yml
+++ b/.github/workflows/live_tests.yml
@@ -92,12 +92,18 @@ jobs:
         run: |
           LEVEL="${{ inputs.test_level || github.event.inputs.test_level || 'lv1' }}"
           echo "TEST_LEVEL=${LEVEL}" >> "$GITHUB_ENV"
+          if [[ "${{ github.event_name }}" == "workflow_call" && "$LEVEL" == "lv2" ]]; then
+            SELECTOR="lv1 or lv2"
+          else
+            SELECTOR="$LEVEL"
+          fi
+          echo "TEST_SELECTOR=${SELECTOR}" >> "$GITHUB_ENV"
 
       - name: "Running tests against a live instance"
         env:
           TARGET_ENV: ${{ matrix.env }}
         run: |
-          uv run pytest --env "$TARGET_ENV" -k "$TEST_LEVEL" \
+          uv run pytest --env "$TARGET_ENV" -k "$TEST_SELECTOR" \
             --junitxml=sdk-test-results.xml \
             --html=sdk-report.html --self-contained-html
 

--- a/.github/workflows/live_tests.yml
+++ b/.github/workflows/live_tests.yml
@@ -89,10 +89,14 @@ jobs:
 
       - name: Set test level
         id: test_level
+        env:
+          INPUT_TEST_LEVEL: ${{ inputs.test_level }}
+          EVENT_TEST_LEVEL: ${{ github.event.inputs.test_level }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
-          LEVEL="${{ inputs.test_level || github.event.inputs.test_level || 'lv1' }}"
+          LEVEL="${INPUT_TEST_LEVEL:-${EVENT_TEST_LEVEL:-lv1}}"
           echo "TEST_LEVEL=${LEVEL}" >> "$GITHUB_ENV"
-          if [[ "${{ github.event_name }}" == "workflow_call" && "$LEVEL" == "lv2" ]]; then
+          if [[ "$EVENT_NAME" == "workflow_call" && "$LEVEL" == "lv2" ]]; then
             SELECTOR="lv1 or lv2"
           else
             SELECTOR="$LEVEL"


### PR DESCRIPTION
- Add trigger-aware test selector resolution in `live_tests.yml`.
- For `workflow_call`, resolve `lv2` to cumulative selector `lv1 or lv2`.
- Keep `workflow_dispatch` behavior unchanged: `lv1` runs `lv1`, `lv2` runs `lv2`.
- Keep JUnit/HTML artifact generation unchanged (`sdk-test-results.xml`, `sdk-report.html`).