### PR TITLE
fix: (QA-650-4) run lv1+lv2 selector for reusable workflow lv2 calls

### DIFF
--- a/.github/workflows/live_tests.yml
+++ b/.github/workflows/live_tests.yml
@@ -91,12 +91,12 @@ jobs:
         id: test_level
         env:
           INPUT_TEST_LEVEL: ${{ inputs.test_level }}
+          INPUT_ENV: ${{ inputs.env }}
           EVENT_TEST_LEVEL: ${{ github.event.inputs.test_level }}
-          EVENT_NAME: ${{ github.event_name }}
         run: |
           LEVEL="${INPUT_TEST_LEVEL:-${EVENT_TEST_LEVEL:-lv1}}"
           echo "TEST_LEVEL=${LEVEL}" >> "$GITHUB_ENV"
-          if [[ "$EVENT_NAME" == "workflow_call" && "$LEVEL" == "lv2" ]]; then
+          if [[ -n "$INPUT_ENV" && "$LEVEL" == "lv2" ]]; then
             SELECTOR="lv1 or lv2"
           else
             SELECTOR="$LEVEL"


### PR DESCRIPTION
## Summary
This is a follow up PR from https://github.com/deeporiginbio/do-dd-client/pull/524

- Fix SDK live-tests selector logic so reusable workflow calls with `test_level=lv2` execute both `lv1` and `lv2` tests.
- Detect reusable-workflow context via `inputs.env` instead of relying on `github.event_name`.
- Preserve direct/manual workflow behavior where `lv2` runs only `lv2`.