### PR TITLE
feat: (DDOS-5209) add generic batch create entity endpoint[deleted]

### DIFF
--- a/src/platform/entities.py
+++ b/src/platform/entities.py
@@ -154,6 +154,38 @@ class Entities:
             f"/data-platform/{self._c.org_key}/{entity}/{entity_id}"
         )
 
+    def batch_create(
+        self,
+        entity: str,
+        *,
+        rows: list[dict[str, Any]],
+        returning: list[str] | None = None,
+    ) -> dict:
+        """Batch create entity rows.
+
+        Calls ``POST /data-platform/{orgKey}/{entity}/batch/create``.
+
+        This method is intentionally generic so tools can persist dataset rows
+        into arbitrary target tables (e.g. result tables), not only the built-in
+        convenience entities like ligands.
+
+        Args:
+            entity: Entity (table) name to batch-create.
+            rows: List of row dicts to persist.
+            returning: Optional list of fields to include in the response.
+
+        Returns:
+            Dictionary containing the batch creation response.
+        """
+        body: dict[str, Any] = {"rows": rows}
+        if returning is not None:
+            body["returning"] = returning
+
+        return self._c.post_json(
+            f"/data-platform/{self._c.org_key}/{entity}/batch/create",
+            body=body,
+        )
+
     # ---- Ligands ----
 
     def search_ligands(

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -189,6 +189,16 @@ def test_create_protein_lv1(client: DeepOriginClient):
     assert "file_path" in data, "Expected 'file_path' key in data"
 
 
+def test_batch_create_entity_lv1(client: DeepOriginClient):
+    """Test batch create via generic entity endpoint."""
+    response = client.entities.batch_create("ligands", rows=[{"smiles": "C"}])
+
+    assert isinstance(response, dict), "Expected a dictionary response"
+    assert "data" in response, "Expected 'data' key in response"
+    assert isinstance(response["data"], list), "Expected 'data' to be a list"
+    assert len(response["data"]) == 1, "Expected exactly one created row"
+
+
 def test_get_ligand_lv1(client: DeepOriginClient):
     """Test getting a ligand by ID."""
     smiles = "Fc1c(-c2cccc3ccccc23)ncc2c(N3C[C@H]4CC[C@@H](C3)N4)nc(OCC34CCCN3CCC4)nc12"


### PR DESCRIPTION
Add a generic batch_create method to the Entities client class to allow tools to persist dataset rows into arbitrary target tables. This enables batch creation beyond built-in convenience entities like ligands.

Update the test suite to include a corresponding test for the new batch create functionality.