### PR TITLE
Add ability to search by multiple tool_key's and by compute_job_id.

### DIFF
--- a/src/platform/executions.py
+++ b/src/platform/executions.py
@@ -192,7 +192,9 @@ class Executions:
         if status is not None:
             props.append({"column": "status", "op": "eq", "value": status})
         if compute_job_id is not None:
-            props.append({"column": "compute_job_id", "op": "eq", "value": compute_job_id})
+            props.append(
+                {"column": "compute_job_id", "op": "eq", "value": compute_job_id}
+            )
         if extra_props:
             props.extend(extra_props)
 

--- a/src/platform/executions.py
+++ b/src/platform/executions.py
@@ -137,13 +137,14 @@ class Executions:
         self,
         *,
         project_id: str | None = None,
-        tool_key: str | None = None,
+        tool_key: list[str] | str | None = None,
         status: str | None = None,
         extra_props: list[dict[str, Any]] | None = None,
         limit: int | None = None,
         offset: int | None = None,
         select: list[str] | None = None,
         with_total_count: bool = False,
+        compute_job_id: str | None = None,
     ) -> dict:
         """Search executions via the data-platform endpoint.
 
@@ -184,10 +185,14 @@ class Executions:
         props: list[dict[str, Any]] = []
         if project_id is not None:
             props.append({"column": "project_id", "op": "eq", "value": project_id})
-        if tool_key is not None:
+        if isinstance(tool_key, (list, tuple)):
+            props.append({"column": "tool_key", "op": "in", "value": tool_key})
+        elif isinstance(tool_key, str) and tool_key:
             props.append({"column": "tool_key", "op": "eq", "value": tool_key})
         if status is not None:
             props.append({"column": "status", "op": "eq", "value": status})
+        if compute_job_id is not None:
+            props.append({"column": "compute_job_id", "op": "eq", "value": compute_job_id})
         if extra_props:
             props.extend(extra_props)
 


### PR DESCRIPTION
This pull request updates the `search` method in `src/platform/executions.py` to enhance its filtering capabilities and flexibility. The main changes allow searching by multiple `tool_key` values and add support for filtering by `compute_job_id`.

**Improvements to search filtering:**

* The `tool_key` parameter now accepts a list of strings, a single string, or `None`, allowing searches for multiple tools at once. The filter logic applies the correct SQL operation (`in` or `eq`) based on the type of `tool_key`. [[1]](diffhunk://#diff-c846de942494e4a05b138c6e0bc40f5dcb17033d8f63f79a3cab617434a54d4bL140-R147) [[2]](diffhunk://#diff-c846de942494e4a05b138c6e0bc40f5dcb17033d8f63f79a3cab617434a54d4bL187-R195)
* Added an optional `compute_job_id` parameter to the `search` method, enabling filtering executions by their associated compute job. [[1]](diffhunk://#diff-c846de942494e4a05b138c6e0bc40f5dcb17033d8f63f79a3cab617434a54d4bL140-R147) [[2]](diffhunk://#diff-c846de942494e4a05b138c6e0bc40f5dcb17033d8f63f79a3cab617434a54d4bL187-R195)