### PR TITLE
feat: promote DataIngesting status to first-class citizen in SDK

### DIFF
--- a/docs/dd/how-to/job.md
+++ b/docs/dd/how-to/job.md
@@ -32,7 +32,7 @@ A dataframe with the following columns will be returned:
 | execution_id | (internal) execution ID. | 
 | completed_at | Time stamp of when the Job was completed |
 | started_at | Time stamp of when the Job was started |
-| status | One of `Succeeded` `Cancelled` `Failed` `Running` `Queued` `Created` `FailedQuotation` `Quoted` or `InsufficientFunds`|
+| status | One of `Succeeded` `Cancelled` `Failed` `DataIngesting` `Running` `Queued` `Created` `FailedQuotation` `Quoted` or `InsufficientFunds`|
 | tool_key | Key of tool corresponding to this Job |
 | tool_version | Version of tool |
 | user_name | Name (or ID) of user that started this job |
@@ -184,12 +184,13 @@ When viewing a job, the status is displayed as a badge in the footer of the job 
   - `Succeeded`: Green (success)  
   - `Failed`/`FailedQuotation`/`InsufficientFunds`: Red (danger)
   - `Cancelled`: Dark gray
+  - `DataIngesting`: Light blue (info) — tool execution completed but result data is still being ingested into the data platform
   - `Created`: Gray (secondary)
   - `Queued`: Light blue (info)
   - `Quoted`: Yellow (warning)
   - Other statuses: Light gray
 
-- **Auto-update Behavior**: The widget automatically stops updating when the job reaches a terminal state (`Succeeded`, `Failed`, `Cancelled`, `FailedQuotation`, `Quoted`, or `InsufficientFunds`)
+- **Auto-update Behavior**: The widget automatically stops updating when the job reaches a terminal state (`Succeeded`, `Failed`, `Cancelled`, `FailedQuotation`, `Quoted`, or `InsufficientFunds`). The `DataIngesting` status is non-terminal, so the widget continues polling through it until the final status is restored.
 
 - **Quoted Status**: When a job has a "Quoted" status, the status tab displays a special message showing the estimated cost and instructions to approve the job. The message includes:
   - A "Job Quoted" heading

--- a/src/drug_discovery/execution_mixins.py
+++ b/src/drug_discovery/execution_mixins.py
@@ -149,7 +149,7 @@ class AsyncExecutableMixin:
                 "Cannot cancel: no execution has been started (id is None)."
             )
 
-        cancellable = {"Created", "Queued", "Running"}
+        cancellable = {"Created", "Queued", "Running", "DataIngesting"}
         if self.status not in cancellable:
             raise ValueError(
                 f"Cannot cancel: job is in {self.status!r} state. "

--- a/src/platform/constants.py
+++ b/src/platform/constants.py
@@ -7,6 +7,7 @@ PlatformStatus = Literal[
     "Created",
     "Queued",
     "Running",
+    "DataIngesting",
     "Succeeded",
     "Failed",
     "Cancelled",
@@ -19,7 +20,8 @@ ALLOWED_STATUS_TRANSITIONS: dict[str | None, set[str]] = {
     "Quoted": {"Created", "Queued", "Running"},
     "Created": {"Queued", "Running", "Failed", "Cancelled"},
     "Queued": {"Running", "Failed", "Cancelled"},
-    "Running": {"Succeeded", "Failed", "Cancelled"},
+    "Running": {"Succeeded", "Failed", "Cancelled", "DataIngesting"},
+    "DataIngesting": {"Succeeded", "Failed", "Cancelled"},
     "Succeeded": set(),
     "Failed": set(),
     "Cancelled": set(),
@@ -38,10 +40,10 @@ TERMINAL_STATES = {
 }
 
 # Non-terminal states for tool executions
-NON_TERMINAL_STATES = {"Created", "Queued", "Running"}
+NON_TERMINAL_STATES = {"Created", "Queued", "Running", "DataIngesting"}
 
 # Non-failed states for tool executions
-NON_FAILED_STATES = {"Succeeded", "Running", "Queued", "Created"}
+NON_FAILED_STATES = {"Succeeded", "Running", "Queued", "Created", "DataIngesting"}
 
 # Possible providers for files that work with the tools API
 PROVIDER = Literal["ufa", "s3"]

--- a/src/platform/execution_display.py
+++ b/src/platform/execution_display.py
@@ -22,6 +22,7 @@ _STATUS_BADGE_VARIANT: dict[str, str] = {
     "Created": "info",
     "Queued": "info",
     "Cancelled": "secondary",
+    "DataIngesting": "info",
     "InsufficientFunds": "warning",
     "FailedQuotation": "warning",
     "New": "secondary",
@@ -261,7 +262,8 @@ class ExecutionDisplay:
             HTML string safe for :class:`IPython.display.HTML`.
 
         Note:
-            The progress bar is rendered only when :attr:`status` is ``"Running"``.
+            The progress bar is rendered when :attr:`status` is ``"Running"``
+            or ``"DataIngesting"``.
         """
         esc_status = html.escape(self.status, quote=True)
         esc_title = html.escape(self._card_header_title(), quote=True)
@@ -284,7 +286,14 @@ class ExecutionDisplay:
                 '<div class="small text-muted mt-2 text-break">'
                 f"<code>{esc_id}</code></div>"
             )
-        if self.status == "Running":
+        if self.status == "DataIngesting":
+            progress_block = (
+                '<div class="progress" style="height: 22px;" role="progress" '
+                'aria-label="Data ingestion in progress">'
+                '<div class="progress-bar progress-bar-striped progress-bar-animated '
+                'bg-info w-100" role="progressbar">Ingesting data\u2026</div></div>'
+            )
+        elif self.status == "Running":
             pct = float(self.complete)
             if pct > 0:
                 width = min(100.0, pct)

--- a/src/platform/executions.py
+++ b/src/platform/executions.py
@@ -321,7 +321,10 @@ class Executions:
             tool_key: Equality filter on ``tool_key`` (e.g.
                 ``"deeporigin.bulk-docking"``).
             status: Equality filter on ``status`` (e.g. ``"Completed"``,
-                ``"Failed"``, ``"Running"``).
+                ``"Failed"``, ``"Running"``, ``"DataIngesting"``).
+                ``DataIngesting`` is a transient DPS-only status indicating
+                the tool execution finished but result data is still being
+                ingested into the data platform.
             extra_props: Additional filter props appended to the
                 built-in ones. Each prop is a dict with
                 ``{"column": str, "op": str, "value": Any}``.

--- a/tests/mock_server/routers/data_platform.py
+++ b/tests/mock_server/routers/data_platform.py
@@ -331,6 +331,34 @@ def _apply_eq_filters(
     return results
 
 
+_DPS_TERMINAL_STATUSES = {"Succeeded", "Failed", "Cancelled"}
+
+
+def _dps_execution_status(ex: dict[str, Any]) -> str | None:
+    """Derive the DPS-visible status for a tools execution dict.
+
+    Mirrors platform DPS behaviour: when the execution metadata contains the
+    ``__data_ingestion_started`` flag and the tools-service status is terminal,
+    the DPS surfaces ``DataIngesting`` instead. Tests can set
+    ``ex["metadata"]["__data_ingestion_started"] = True`` to trigger this.
+
+    Args:
+        ex: Tools-service execution dict from the mock store.
+
+    Returns:
+        Status string as it would appear in DPS search results.
+    """
+    tools_status = ex.get("status")
+    meta = ex.get("metadata") or {}
+    if (
+        isinstance(meta, dict)
+        and meta.get("__data_ingestion_started") is True
+        and tools_status in _DPS_TERMINAL_STATUSES
+    ):
+        return "DataIngesting"
+    return tools_status
+
+
 def create_data_platform_router(
     *,
     ligands: dict[str, dict[str, Any]],
@@ -697,11 +725,12 @@ def create_data_platform_router(
             for _ex_key, ex in executions.items():
                 eid = ex.get("executionId") or _ex_key
                 tool = ex.get("tool") or {}
+                status = _dps_execution_status(ex)
                 dp_rows[str(eid)] = {
                     "id": str(eid),
                     "tool_key": tool.get("key"),
                     "tool_version": tool.get("version"),
-                    "status": ex.get("status"),
+                    "status": status,
                     "started_at": ex.get("startedAt"),
                     "completed_at": ex.get("completedAt"),
                     "compute_job_id": ex.get("executionId"),

--- a/tests/test_execution_display.py
+++ b/tests/test_execution_display.py
@@ -299,6 +299,32 @@ def test_render_html_workflow_footer_badge() -> None:
     assert "bg-secondary-subtle" in html
 
 
+def test_data_ingesting_badge_uses_info_variant() -> None:
+    """DataIngesting status uses the ``bg-info`` badge class."""
+    dto = {
+        "executionId": "e1",
+        "status": "DataIngesting",
+        "progressReport": None,
+    }
+    html = ExecutionDisplay.from_dto(dto).render_html()
+    assert "bg-info" in html
+    assert "DataIngesting" in html
+
+
+def test_data_ingesting_renders_indeterminate_progress_bar() -> None:
+    """DataIngesting renders an animated striped progress bar with label."""
+    dto = {
+        "executionId": "e1",
+        "status": "DataIngesting",
+        "progressReport": None,
+    }
+    html = ExecutionDisplay.from_dto(dto).render_html()
+    assert "progress-bar-striped" in html
+    assert "progress-bar-animated" in html
+    assert "Ingesting data" in html
+    assert 'aria-label="Data ingestion in progress"' in html
+
+
 def test_render_html_no_workflow_badge_when_absent() -> None:
     """No workflow badge when there are no workflow-* keys."""
     html = ExecutionDisplay.from_dto(

--- a/tests/test_execution_mixins.py
+++ b/tests/test_execution_mixins.py
@@ -132,3 +132,20 @@ def test_async_start_rejects_non_none_status() -> None:
         job.start()
 
     assert not job._start_impl_calls
+
+
+def test_cancel_allows_data_ingesting_status() -> None:
+    """``cancel()`` does not reject ``DataIngesting`` status."""
+    client = MagicMock()
+    client.executions.get.return_value = {
+        "executionId": "exec-di",
+        "tool": {"key": "deeporigin.test-tool", "version": "0.0.0"},
+        "status": "Cancelled",
+    }
+    job = _AsyncJob(client=client)
+    job._id = "exec-di"
+    job.status = "DataIngesting"
+
+    job.cancel()
+
+    client.executions.cancel.assert_called_once_with("exec-di")

--- a/tests/test_executions.py
+++ b/tests/test_executions.py
@@ -397,6 +397,41 @@ def test_wait_rejects_empty_string_id() -> None:
         executions.wait(["a", ""], poll_interval=0.1)
 
 
+def test_wait_polls_through_data_ingesting(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``wait`` treats ``DataIngesting`` as non-terminal and keeps polling."""
+    responses = [
+        {"executionId": "a", "status": "DataIngesting"},
+        {"executionId": "a", "status": "DataIngesting"},
+        {"executionId": "a", "status": "Succeeded"},
+    ]
+    executions = _make_executions(get_side_effect=responses)
+
+    sleeps: list[float] = []
+    monkeypatch.setattr(
+        "deeporigin.platform.executions.time.sleep", lambda s: sleeps.append(s)
+    )
+
+    result = executions.wait(["a"], poll_interval=0.5)
+
+    assert result == [{"executionId": "a", "status": "Succeeded"}]
+    assert executions.get.call_count == 3  # ty:ignore[unresolved-attribute]
+    assert len(sleeps) == 2
+
+
+def test_cancel_skips_when_data_ingesting() -> None:
+    """``cancel`` does not return early for ``DataIngesting`` (non-terminal)."""
+    client = MagicMock()
+    client.org_key = "org-1"
+    executions = Executions(client)
+    executions.get = MagicMock(  # ty:ignore[assignment]
+        return_value={"executionId": "e1", "status": "DataIngesting"}
+    )
+
+    executions.cancel("e1")
+
+    client._patch.assert_called_once_with("/tools/org-1/tools/executions/e1:cancel")
+
+
 def test_list_executions_by_session_lv1(client: DeepOriginClient):
     """Test listing executions by session — server-side filter must drop
     executions whose non-null session does not match.

--- a/tests/test_notebook_watch_mixin.py
+++ b/tests/test_notebook_watch_mixin.py
@@ -145,6 +145,47 @@ def test_watch_async_raises_when_dto_missing_after_sync(
         asyncio.run(abfe.watch_async())
 
 
+@patch("deeporigin.drug_discovery.notebook_watch_mixin.display")
+@patch("deeporigin.drug_discovery.notebook_watch_mixin.update_display")
+def test_watch_async_polls_through_data_ingesting(mock_update_display, mock_display):
+    """DataIngesting is non-terminal; watch_async keeps polling through it."""
+    ps = PreparedSystem(
+        binding_xml_path="b.xml",
+        solvation_xml_path="s.xml",
+        system_pdb_path="p.pdb",
+    )
+    ingesting = _minimal_dto(status="DataIngesting")
+    succeeded = _minimal_dto(status="Succeeded")
+
+    mock_client = MagicMock()
+    mock_client.executions.get.side_effect = [ingesting, succeeded]
+
+    abfe = ABFE(prepared_system=ps)
+    abfe.client = mock_client
+    abfe._id = ingesting["executionId"]
+    abfe._dto = ingesting
+    abfe.status = "DataIngesting"
+
+    with patch.object(abfe, "_render_execution_html", return_value="<html>x</html>"):
+        asyncio.run(abfe.watch_async(interval=0.001))
+
+    assert mock_client.executions.get.call_count >= 2
+    assert mock_update_display.call_count >= 1
+
+
+def test_is_terminal_returns_false_for_data_ingesting():
+    """``_is_terminal()`` returns False for DataIngesting."""
+    ps = PreparedSystem(
+        binding_xml_path="b.xml",
+        solvation_xml_path="s.xml",
+        system_pdb_path="p.pdb",
+    )
+    abfe = ABFE(prepared_system=ps)
+    abfe.status = "DataIngesting"
+
+    assert abfe._is_terminal() is False
+
+
 def test_watch_returns_task_without_blocking_watch_async():
     """watch returns a Task; watch_async runs asynchronously."""
 


### PR DESCRIPTION
## Add `DataIngesting` as a first-class execution status

DPS synthesizes a transient `DataIngesting` status while result data is being ingested after tool execution completes. This PR teaches the SDK about it:

- Added to `PlatformStatus` Literal, transition map, and non-terminal/non-failed sets
- Badge renders as light-blue (`info`) with an animated "Ingesting data…" progress bar
- `cancel()` now permitted during `DataIngesting`
- `wait()` and `watch_async()` automatically poll through it (non-terminal)
- DPS mock simulates the status via `metadata.__data_ingestion_started`
- 7 new tests covering polling, cancellation, display, and terminal checks
- Docs updated