### PR TITLE
fix(DDOS-5247): update test_list_organizations_lv1 assertions for Keycloak path

### DIFF
--- a/tests/test_organizations.py
+++ b/tests/test_organizations.py
@@ -11,8 +11,6 @@ def test_list_organizations_lv1(client: DeepOriginClient):
     assert len(orgs) > 0, "Expected at least one organization"
     org = orgs[0]
     for key in [
-        "createdAt",
-        "updatedAt",
         "orgKey",
         "name",
         "mfaEnabled",
@@ -20,7 +18,6 @@ def test_list_organizations_lv1(client: DeepOriginClient):
         "autoApproveMaxAmount",
         "status",
         "id",
-        "invites",
         "roles",
     ]:
         assert key in org, f"Expected organization to have key {key}"


### PR DESCRIPTION
## Summary

- `test_list_organizations_lv1` was asserting `createdAt`, `updatedAt`, and `invites` on org objects



## Test plan

- [ ] `test_list_organizations_lv1` passes on next CI run against dev

