### PR TITLE
feat: add direct link to developer tokens page

### DIFF
--- a/docs/how-to/auth.md
+++ b/docs/how-to/auth.md
@@ -4,7 +4,7 @@
 
 To use the Deep Origin client, you must first obtain an API token. 
 
-Navigate to the developer tokens tab in your Deep Origin account. You will see a screen similar to:
+Navigate to the [developer tokens tab](https://os.deeporigin.io/settings?tab=tokens) in your Deep Origin account. You will see a screen similar to:
 
 ![](../images/token-1.png)
 


### PR DESCRIPTION
## Summary
Updated the authentication documentation to include a direct hyperlink to the developer tokens settings page, improving user experience by reducing navigation steps.

## Changes
- Added markdown link to the developer tokens tab at `https://os.deeporigin.io/settings?tab=tokens` in the auth.md documentation
- This allows users to navigate directly to the tokens page instead of manually finding it in their account settings

## Details
The change converts plain text reference to "developer tokens tab" into a clickable link that directs users to the exact location in their Deep Origin account where they can obtain API tokens. This streamlines the onboarding process for new users setting up authentication.

https://claude.ai/code/session_018UgCaSVBpiD3UGEKuzLbum