### PR TITLE
DDOS-6834: fix: harden SDK live tests and stop retrying execution create

### DIFF
--- a/docs/dev/clients.md
+++ b/docs/dev/clients.md
@@ -128,6 +128,10 @@ The client automatically retries requests that fail with:
 
 The client does not retry on client errors (4xx status codes except 429), as these typically indicate issues with the request itself rather than transient server problems.
 
+``executions.create`` (tool ``run()`` / ``start()`` / quote) always uses a
+**single HTTP attempt** (`retry=False`). Retrying a timed-out sync create can
+spawn duplicate long-running tool work after an upstream gateway 504.
+
 ### Configuring Retries
 
 You can customize retry behavior when creating a client:

--- a/src/platform/entities.py
+++ b/src/platform/entities.py
@@ -53,6 +53,7 @@ LIGAND_RETURNING_FIELDS = [
     "tpsa",
     "molecular_weight",
     "structure_key",
+    "tags",
 ]
 
 PROTEIN_RETURNING_FIELDS = [

--- a/src/platform/executions.py
+++ b/src/platform/executions.py
@@ -77,6 +77,8 @@ class Executions:
                 caller already included ``tag`` in ``data``. When
                 ``client.billing_tag`` is set, it is sent as ``billing`` unless
                 the caller already included ``billing`` in ``data``.
+                Uses ``retry=False`` so a failed create (including gateway 504)
+                is not retried; retries can otherwise duplicate long sync jobs.
 
         Returns:
             Dictionary containing the execution response from the API.
@@ -105,10 +107,13 @@ class Executions:
             timeout if timeout is not None else TOOL_EXECUTION_POST_TIMEOUT_SECONDS
         )
 
+        # Single attempt: retrying a timed-out sync create can spawn duplicate
+        # long-running tool work (e.g. system-prep behind an nginx 504).
         return self._c.post_json(
             f"/tools/{self._c.org_key}/tools/{tool_key}/{tool_version}/executions",
             body=payload,
             timeout=req_timeout,
+            retry=False,
         )
 
     def _list_tools_executions_page(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -74,6 +74,7 @@ def _stub_post_json_capturing_body(client: DeepOriginClient) -> dict:
         captured.update(body)
         captured["__endpoint__"] = endpoint
         captured["__timeout__"] = kwargs.get("timeout")
+        captured["__retry__"] = kwargs.get("retry")
         return {
             "executionId": "exec-stub",
             "status": "Completed",
@@ -129,6 +130,26 @@ def test_executions_create_uses_long_timeout():
     )
 
     assert captured["__timeout__"] == TOOL_EXECUTION_POST_TIMEOUT_SECONDS
+
+
+def test_executions_create_disables_retry():
+    """``executions.create`` uses a single HTTP attempt (``retry=False``)."""
+    DeepOriginClient.close_all()
+
+    client = DeepOriginClient.from_local()
+    captured = _stub_post_json_capturing_body(client)
+
+    client.clusters.get_default_cluster_id = (  # type: ignore[method-assign]
+        lambda: "test-cluster-id"
+    )
+
+    client.executions.create(
+        tool_key="test.tool",
+        tool_version="1.0.0",
+        data={"inputs": {"test": "param"}, "outputs": {}, "metadata": {}},
+    )
+
+    assert captured["__retry__"] is False
 
 
 def test_executions_create_includes_client_project_id():

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -1,8 +1,8 @@
 """Tests for the Entities API wrapper."""
 
+import time
 import uuid
 
-import httpx
 import pytest
 
 from deeporigin.drug_discovery import BRD_DATA_DIR
@@ -12,6 +12,8 @@ from deeporigin.platform import DeepOriginClient
 
 _BRD_PDB_LOCAL = BRD_DATA_DIR / "brd.pdb"
 _BRD_PDB_REMOTE = "testing/brd.pdb"
+_GET_LIGAND_POLL_SECONDS = 15.0
+_GET_LIGAND_POLL_INTERVAL = 0.5
 
 
 def _expected_entity_tags(
@@ -23,6 +25,60 @@ def _expected_entity_tags(
     expected.setdefault("app", client._app)
     expected.setdefault("session", client._session)
     return expected
+
+
+def _unique_test_smiles(*, suffix: str = "O") -> str:
+    """Build a one-off aliphatic SMILES unlikely to collide with existing ligands.
+
+    Common short SMILES (``CCO``, ``CCC``, …) often resolve to soft-deleted
+    historical rows whose versioned GET still 404s. A long unique carbon chain
+    forces a fresh insert.
+
+    Args:
+        suffix: Terminal heteroatom / group appended after the carbon chain.
+
+    Returns:
+        SMILES string unique for this process invocation.
+    """
+    n = (int(uuid.uuid4().hex[:8], 16) % 40) + 12
+    return ("C" * n) + suffix
+
+
+def _wait_for_ligand(client: DeepOriginClient, lig_id: str) -> dict:
+    """Poll until a ligand row is readable via GET or search-by-id.
+
+    Args:
+        client: Platform client.
+        lig_id: Ligand entity id returned from create/register/sync.
+
+    Returns:
+        Ligand row dict.
+
+    Raises:
+        DeepOriginException: If the row is still missing after
+            ``_GET_LIGAND_POLL_SECONDS``.
+    """
+    deadline = time.monotonic() + _GET_LIGAND_POLL_SECONDS
+    last_error: DeepOriginException | None = None
+    while time.monotonic() < deadline:
+        try:
+            return client.entities.get_ligand(lig_id)
+        except DeepOriginException as exc:
+            if "404" not in str(exc):
+                raise
+            last_error = exc
+        rows = client.entities.get_ligands([lig_id])
+        if rows:
+            return rows[0]
+        time.sleep(_GET_LIGAND_POLL_INTERVAL)
+    raise DeepOriginException(
+        title="Ligand not readable after create",
+        message=(
+            f"get_ligand/get_ligands still missing {lig_id!r} after "
+            f"{_GET_LIGAND_POLL_SECONDS:.0f}s"
+            + (f": {last_error}" if last_error is not None else ".")
+        ),
+    ) from last_error
 
 
 def test_search_entity_lv1(client: DeepOriginClient):
@@ -49,9 +105,6 @@ def test_search_ligands_lv1(client: DeepOriginClient):
     assert isinstance(response["data"], list), "Expected 'data' to be a list"
 
 
-@pytest.mark.xfail(
-    raises=httpx.ReadTimeout, strict=False, reason="platform search timeout"
-)
 def test_search_ligands_molecular_weight_lv1(client: DeepOriginClient):
     """Test searching ligands with molecular weight filters."""
     response = client.entities.search_ligands(
@@ -373,23 +426,16 @@ def test_create_ligand_with_tags_lv1(client: DeepOriginClient):
     """Create ligand persists tags on the platform row."""
     tag = f"tags-{uuid.uuid4().hex[:12]}"
     entity_tags = {"campaign": tag}
+    smiles = _unique_test_smiles(suffix="O")
     create = client.entities.create_ligand(
-        smiles="CC(C)C",
+        smiles=smiles,
         name=f"tagged-ligand-{tag}",
         tags=entity_tags,
     )
     lig_id = create["data"]["id"]
+    expected = _expected_entity_tags(client, entity_tags)
     try:
-        try:
-            row = client.entities.get_ligand(lig_id)
-        except DeepOriginException as _e:
-            if "404" in str(_e):
-                pytest.skip(
-                    f"get_ligand returned 404 for {lig_id!r}; "
-                    "platform versioned-entity GET not yet consistent."
-                )
-            raise
-        assert row["tags"] == _expected_entity_tags(client, entity_tags)
+        assert create["data"].get("tags") == expected
     finally:
         try:
             client.entities.delete(entity="ligands", entity_id=lig_id)
@@ -401,21 +447,20 @@ def test_create_ligand_with_tags_lv1(client: DeepOriginClient):
 def test_update_ligand_with_tags_lv1(client: DeepOriginClient):
     """Update ligand can set tags (jsonb object)."""
     tag = f"upd-tags-{uuid.uuid4().hex[:12]}"
-    create = client.entities.create_ligand(smiles="CCO", name=f"tag-upd-{tag}")
+    smiles = _unique_test_smiles(suffix="N")
+    create = client.entities.create_ligand(smiles=smiles, name=f"tag-upd-{tag}")
     lig_id = create["data"]["id"]
     entity_tags = {"batch": tag}
+    expected = _expected_entity_tags(client, entity_tags)
     try:
-        client.entities.update_ligand(lig_id, tags=entity_tags)
-        try:
-            row = client.entities.get_ligand(lig_id)
-        except DeepOriginException as _e:
-            if "404" in str(_e):
-                pytest.skip(
-                    f"get_ligand returned 404 for {lig_id!r}; "
-                    "platform versioned-entity GET not yet consistent."
-                )
-            raise
-        assert row["tags"] == _expected_entity_tags(client, entity_tags)
+        updated = client.entities.update_ligand(lig_id, tags=entity_tags)
+        updated_data = updated.get("data") if isinstance(updated, dict) else None
+        if isinstance(updated_data, list):
+            updated_row = updated_data[0] if updated_data else None
+        else:
+            updated_row = updated_data
+        assert isinstance(updated_row, dict)
+        assert updated_row.get("tags") == expected
     finally:
         try:
             client.entities.delete(entity="ligands", entity_id=lig_id)
@@ -427,19 +472,12 @@ def test_update_ligand_with_tags_lv1(client: DeepOriginClient):
 def test_create_ligand_stamps_provenance_without_tags_lv1(client: DeepOriginClient):
     """Create ligand without tags still writes app/session provenance."""
     tag = f"prov-{uuid.uuid4().hex[:12]}"
-    create = client.entities.create_ligand(smiles="CCN", name=f"prov-lig-{tag}")
+    smiles = _unique_test_smiles(suffix="F")
+    create = client.entities.create_ligand(smiles=smiles, name=f"prov-lig-{tag}")
     lig_id = create["data"]["id"]
+    expected = _expected_entity_tags(client)
     try:
-        try:
-            row = client.entities.get_ligand(lig_id)
-        except DeepOriginException as _e:
-            if "404" in str(_e):
-                pytest.skip(
-                    f"get_ligand returned 404 for {lig_id!r}; "
-                    "platform versioned-entity GET not yet consistent."
-                )
-            raise
-        assert row["tags"] == _expected_entity_tags(client)
+        assert create["data"].get("tags") == expected
     finally:
         try:
             client.entities.delete(entity="ligands", entity_id=lig_id)
@@ -452,20 +490,14 @@ def test_ligand_register_passes_tags_lv1(client: DeepOriginClient):
     """Ligand.register forwards Entity.tags to create_ligand."""
     tag = f"reg-{uuid.uuid4().hex[:12]}"
     entity_tags = {"origin": tag}
-    ligand = Ligand.from_smiles("CCC", tags=entity_tags)
+    smiles = _unique_test_smiles(suffix="Cl")
+    ligand = Ligand.from_smiles(smiles, tags=entity_tags)
     ligand.register(client=client)
     assert ligand.id is not None
+    expected = _expected_entity_tags(client, entity_tags)
     try:
-        try:
-            row = client.entities.get_ligand(ligand.id)
-        except DeepOriginException as _e:
-            if "404" in str(_e):
-                pytest.skip(
-                    f"get_ligand returned 404 for {ligand.id!r}; "
-                    "platform versioned-entity GET not yet consistent."
-                )
-            raise
-        assert row["tags"] == _expected_entity_tags(client, entity_tags)
+        row = _wait_for_ligand(client, ligand.id)
+        assert row["tags"] == expected
     finally:
         try:
             client.entities.delete(entity="ligands", entity_id=ligand.id)
@@ -477,22 +509,16 @@ def test_ligand_register_passes_tags_lv1(client: DeepOriginClient):
 def test_ligand_sync_applies_tags_to_existing_row_lv1(client: DeepOriginClient):
     """When sync finds an existing ligand, ``Entity.tags`` are patched on."""
     tag = f"sync-tags-{uuid.uuid4().hex[:12]}"
-    create = client.entities.create_ligand(smiles="CCCC", name=f"sync-tag-{tag}")
+    smiles = _unique_test_smiles(suffix="Br")
+    create = client.entities.create_ligand(smiles=smiles, name=f"sync-tag-{tag}")
     lig_id = create["data"]["id"]
     entity_tags = {"patched": tag}
+    expected = _expected_entity_tags(client, entity_tags)
     try:
-        ligand = Ligand.from_smiles("CCCC", tags=entity_tags)
+        ligand = Ligand.from_smiles(smiles, tags=entity_tags)
         ligand.sync(client=client)
-        try:
-            row = client.entities.get_ligand(lig_id)
-        except DeepOriginException as _e:
-            if "404" in str(_e):
-                pytest.skip(
-                    f"get_ligand returned 404 for {lig_id!r}; "
-                    "platform versioned-entity GET not yet consistent."
-                )
-            raise
-        assert row["tags"] == _expected_entity_tags(client, entity_tags)
+        row = _wait_for_ligand(client, lig_id)
+        assert row["tags"] == expected
     finally:
         try:
             client.entities.delete(entity="ligands", entity_id=lig_id)

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -423,7 +423,7 @@ def test_update_ligand_not_found_lv1(client: DeepOriginClient):
 
 
 def test_create_ligand_with_tags_lv1(client: DeepOriginClient):
-    """Create ligand persists tags on the platform row."""
+    """Create ligand returns tags (incl. provenance) on the write response."""
     tag = f"tags-{uuid.uuid4().hex[:12]}"
     entity_tags = {"campaign": tag}
     smiles = _unique_test_smiles(suffix="O")

--- a/tests/test_executions.py
+++ b/tests/test_executions.py
@@ -260,25 +260,51 @@ def test_execution_get_user_logs_returns_dataframe() -> None:
 def test_execution_get_user_logs_lv1(client: DeepOriginClient) -> None:
     """Load a succeeded execution and fetch user_logs scoped to its execution id."""
 
-    search = client.executions.search(status="Completed", limit=200)  # ty:ignore[unresolved-attribute]
-    rows = search.get("data") or []
-    succeeded = [r for r in rows if r.get("status") in ("Completed", "Succeeded")]
-    if not succeeded:
+    # Prefer tools-native list so candidate IDs are known-loadable via GET.
+    listed = client.executions.list(page_size=50, order="createdAt desc")  # ty:ignore[unresolved-attribute]
+    list_rows = listed.get("data") or []
+    candidates: list[str] = []
+    for row in list_rows:
+        status = row.get("status")
+        if status not in ("Completed", "Succeeded"):
+            continue
+        exec_id = str(row.get("executionId") or row.get("id") or "")
+        if exec_id:
+            candidates.append(exec_id)
+
+    if not candidates:
+        search = client.executions.search(status="Completed", limit=200)  # ty:ignore[unresolved-attribute]
+        rows = search.get("data") or []
+        for row in rows:
+            if row.get("status") not in ("Completed", "Succeeded"):
+                continue
+            candidate = str(
+                row.get("compute_job_id")
+                or row.get("executionId")
+                or row.get("id")
+                or ""
+            )
+            if candidate:
+                candidates.append(candidate)
+
+    if not candidates:
         pytest.skip("no succeeded execution visible for this account")
 
-    row = succeeded[0]
-    # Data-platform rows often use ``id`` for the row key; tools ``GET`` needs the
-    # compute job UUID (``compute_job_id`` on DP rows, ``executionId`` on tools DTOs).
-    candidate = str(
-        row.get("compute_job_id") or row.get("executionId") or row.get("id") or ""
-    )
-    if not candidate:
-        pytest.skip("succeeded execution row missing execution id")
+    dto = None
+    last_error: DeepOriginException | None = None
+    for candidate in candidates[:20]:
+        try:
+            dto = client.executions.get(candidate)  # ty:ignore[unresolved-attribute]
+            break
+        except DeepOriginException as exc:
+            last_error = exc
+            continue
 
-    try:
-        dto = client.executions.get(candidate)  # ty:ignore[unresolved-attribute]
-    except DeepOriginException:
-        pytest.skip(f"tools API cannot load execution id {candidate!r}")
+    if dto is None:
+        pytest.skip(
+            "tools API cannot load any candidate execution id"
+            + (f" (last error: {last_error})" if last_error is not None else "")
+        )
 
     exec_id = str(dto.get("executionId") or "")
     if not exec_id:


### PR DESCRIPTION
## Summary

Addresses staging Client SDK report failures/problems:

- **`executions.create` no longer retries** (including on 504). Sync tool failures fail once instead of ~7.5 min of duplicate system-prep work behind nginx timeouts.
- Removed obsolete `@pytest.mark.xfail` on ligand MW search (was XPASS).
- Ligand create/update **return `tags`**; tag tests use unique SMILES and assert write responses (common SMILES were hitting soft-deleted rows that 404 on GET).
- `test_execution_get_user_logs_lv1` prefers tools-native `list` and iterates candidates.

**Verified**
- Local unit/mock subset: pass
- Live `--env a1ce` / `--env staging` (mapped a1ce→`dev`): MW, tag, user-logs tests pass
- Staging `test_sysprep_lv2[backend_only]`: still **504** from nginx, but fails in **~64s** (single attempt) instead of multi-retry hang — fail-hard as intended

Platform/infra follow-up: served-tool system-prep sync overruns gateway budget; not addressable by async convert (served-only).

<!-- merge-ready:auto -->
### Merge-ready status

_Auto-updated — cycle 2, last updated: 2026-07-14T20:22:09Z_

| Check | Status |
|-------|--------|
| Branch vs `main` | ✅ synced at `31d8a1c` |
| Head | `49c9871` |
| CI | ✅ green (12/12) |
| Copilot | ✅ reviewed `49c9871`, 0 open threads |
| Review threads | 0 human/Bugbot, 0 Copilot |

**Recent activity**
- Copilot re-reviewed `49c9871` with no new comments.
- Prior docstring nit resolved; CI green; branch synced with `main`.
- **merge-ready complete.**
<!-- /merge-ready:auto -->






## Test plan

- [x] `uv run pytest --env local -k '…entities…executions…client…system_prep…'`
- [x] Live entity/logs subset on `dev` and `staging`
- [x] Staging sysprep backend_only confirms no-retry fail-fast on 504




