### PR TITLE
feat: expose protonation concentration on Ligand

### DIFF
--- a/src/drug_discovery/protonation.py
+++ b/src/drug_discovery/protonation.py
@@ -191,7 +191,9 @@ class Protonation(Execution, SyncExecutableMixin):
                 inp.mol = new_mol
                 inp.smiles = smi
                 inp.protonated_at_ph = float(self._ph)
-                inp.protonation_concentration = float(conc) if conc is not None else None
+                inp.protonation_concentration = (
+                    float(conc) if conc is not None else None
+                )
                 ligands_out.append(inp)
                 continue
             if n_states == 1:

--- a/src/drug_discovery/protonation.py
+++ b/src/drug_discovery/protonation.py
@@ -176,11 +176,13 @@ class Protonation(Execution, SyncExecutableMixin):
             raise ValueError(
                 "Protonation response missing protonation_states.smiles_list"
             )
+        concentration_list = states.get("concentration_list") or []
 
         base_name = input_first.name or ""
         ligands_out: list[Ligand] = []
         n_states = len(smiles_list)
         for i, smi in enumerate(smiles_list):
+            conc = concentration_list[i] if i < len(concentration_list) else None
             if i == 0 and self._merge_first_state_into_primary:
                 inp = input_first
                 new_mol = Chem.MolFromSmiles(smi)
@@ -189,6 +191,7 @@ class Protonation(Execution, SyncExecutableMixin):
                 inp.mol = new_mol
                 inp.smiles = smi
                 inp.protonated_at_ph = float(self._ph)
+                inp.protonation_concentration = float(conc) if conc is not None else None
                 ligands_out.append(inp)
                 continue
             if n_states == 1:
@@ -199,6 +202,7 @@ class Protonation(Execution, SyncExecutableMixin):
                 nm = f"state_{i + 1}"
             child = Ligand.from_smiles(smi, name=nm)
             child.protonated_at_ph = float(self._ph)
+            child.protonation_concentration = float(conc) if conc is not None else None
             ligands_out.append(child)
 
         result = LigandSet(ligands=ligands_out)

--- a/src/drug_discovery/structures/ligand.py
+++ b/src/drug_discovery/structures/ligand.py
@@ -183,6 +183,7 @@ class Ligand(Entity):
     properties: dict = field(default_factory=dict)
     mol: Chem.Mol = field(kw_only=True)
     protonated_at_ph: float | None = None
+    protonation_concentration: float | None = None
     # Molprops / ADMET (populated by Molprops.run(); see _MOLPROPS_RESPONSE_TO_ATTR
     # for the API-key → attribute mapping for the combined molprops tool).
     log_s: float | None = None

--- a/tests/test_ligand.py
+++ b/tests/test_ligand.py
@@ -795,6 +795,39 @@ def test_ligand_protonate_sets_protonated_at_ph(client: DeepOriginClient):
     assert len(result.ligands) == 2
 
 
+def test_protonation_exposes_concentration(client: DeepOriginClient):
+    """Protonation.run() sets protonation_concentration on returned ligands."""
+    result = Protonation(smiles="CCO", ph=7.4, client=client).run()
+
+    assert len(result.ligands) >= 1
+    for lig in result.ligands:
+        assert lig.protonation_concentration is not None
+        assert isinstance(lig.protonation_concentration, float)
+        assert lig.protonation_concentration > 0
+
+
+def test_protonation_concentration_multi_state(client: DeepOriginClient):
+    """Multi-state protonation returns distinct concentrations that sum to ~100%."""
+    smiles = "C=CCCn1cc(-c2cccc(C(=O)N(C)C)c2)c2cc[nH]c2c1=O"
+    result = Protonation(smiles=smiles, ph=11.4, client=client).run()
+
+    assert len(result.ligands) == 2
+    concentrations = [lig.protonation_concentration for lig in result.ligands]
+    assert all(c is not None for c in concentrations)
+    assert sum(concentrations) == pytest.approx(100.0, abs=1.0)
+    assert concentrations[0] > concentrations[1]
+
+
+def test_protonation_concentration_on_merged_primary(client: DeepOriginClient):
+    """Concentration is set on the primary ligand when using ligand= input."""
+    ligand = Ligand.from_smiles("CCO")
+    result = Protonation(ligand=ligand, ph=7.4, client=client).run()
+
+    assert result.ligands[0] is ligand
+    assert ligand.protonation_concentration is not None
+    assert isinstance(ligand.protonation_concentration, float)
+
+
 @pytest.mark.parametrize(
     "sdf_file", sorted(BRD_DATA_DIR.glob("*.sdf")), ids=lambda p: p.stem
 )

--- a/tests/test_protonation_unit.py
+++ b/tests/test_protonation_unit.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from unittest.mock import patch
-
 import pytest
 
 from deeporigin.drug_discovery.protonation import Protonation, _execution_outputs_dict
@@ -80,71 +78,3 @@ def test_protonation_make_payload_sync_flag() -> None:
     assert payload["inputs"]["ligand"]["smiles"] == "CCO"
 
 
-def test_run_exposes_concentration_list() -> None:
-    """run() sets protonation_concentration on each returned Ligand."""
-    job = Protonation(smiles="CCO", ph=11.4)
-
-    mock_response = {
-        "jobOutputs": {
-            "smiles": "CCO",
-            "pH": 11.4,
-            "filter_percentage": 1,
-            "protonation_states": {
-                "smiles_list": ["[O-]CC", "OCC"],
-                "concentration_list": [79.69, 20.31],
-            },
-        },
-    }
-    with patch.object(job, "_create_execution", return_value=mock_response):
-        result = job.run()
-
-    assert len(result.ligands) == 2
-    assert result.ligands[0].protonation_concentration == pytest.approx(79.69)
-    assert result.ligands[1].protonation_concentration == pytest.approx(20.31)
-    assert result.ligands[0].protonated_at_ph == 11.4
-    assert result.ligands[1].protonated_at_ph == 11.4
-
-
-def test_run_handles_missing_concentration_list() -> None:
-    """run() gracefully handles responses without concentration_list."""
-    job = Protonation(smiles="CCO", ph=7.4)
-
-    mock_response = {
-        "jobOutputs": {
-            "smiles": "CCO",
-            "pH": 7.4,
-            "filter_percentage": 1,
-            "protonation_states": {
-                "smiles_list": ["OCC"],
-            },
-        },
-    }
-    with patch.object(job, "_create_execution", return_value=mock_response):
-        result = job.run()
-
-    assert len(result.ligands) == 1
-    assert result.ligands[0].protonation_concentration is None
-    assert result.ligands[0].protonated_at_ph == 7.4
-
-
-def test_run_sets_concentration_on_merged_primary() -> None:
-    """run() sets concentration when merging into the primary ligand (ligand= path)."""
-    ligand = Ligand.from_smiles("CCO", name="ethanol")
-    job = Protonation(ligand=ligand, ph=7.4)
-
-    mock_response = {
-        "jobOutputs": {
-            "smiles": "CCO",
-            "pH": 7.4,
-            "filter_percentage": 1,
-            "protonation_states": {
-                "smiles_list": ["OCC"],
-                "concentration_list": [99.93],
-            },
-        },
-    }
-    with patch.object(job, "_create_execution", return_value=mock_response):
-        result = job.run()
-
-    assert result.ligands[0] is ligand
-    assert ligand.protonation_concentration == pytest.approx(99.93)

--- a/tests/test_protonation_unit.py
+++ b/tests/test_protonation_unit.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from unittest.mock import patch
+
 import pytest
 
 from deeporigin.drug_discovery.protonation import Protonation, _execution_outputs_dict
@@ -76,3 +78,73 @@ def test_protonation_make_payload_sync_flag() -> None:
     assert payload["sync"] is True
     assert payload["approveAmount"] == 0
     assert payload["inputs"]["ligand"]["smiles"] == "CCO"
+
+
+def test_run_exposes_concentration_list() -> None:
+    """run() sets protonation_concentration on each returned Ligand."""
+    job = Protonation(smiles="CCO", ph=11.4)
+
+    mock_response = {
+        "jobOutputs": {
+            "smiles": "CCO",
+            "pH": 11.4,
+            "filter_percentage": 1,
+            "protonation_states": {
+                "smiles_list": ["[O-]CC", "OCC"],
+                "concentration_list": [79.69, 20.31],
+            },
+        },
+    }
+    with patch.object(job, "_create_execution", return_value=mock_response):
+        result = job.run()
+
+    assert len(result.ligands) == 2
+    assert result.ligands[0].protonation_concentration == pytest.approx(79.69)
+    assert result.ligands[1].protonation_concentration == pytest.approx(20.31)
+    assert result.ligands[0].protonated_at_ph == 11.4
+    assert result.ligands[1].protonated_at_ph == 11.4
+
+
+def test_run_handles_missing_concentration_list() -> None:
+    """run() gracefully handles responses without concentration_list."""
+    job = Protonation(smiles="CCO", ph=7.4)
+
+    mock_response = {
+        "jobOutputs": {
+            "smiles": "CCO",
+            "pH": 7.4,
+            "filter_percentage": 1,
+            "protonation_states": {
+                "smiles_list": ["OCC"],
+            },
+        },
+    }
+    with patch.object(job, "_create_execution", return_value=mock_response):
+        result = job.run()
+
+    assert len(result.ligands) == 1
+    assert result.ligands[0].protonation_concentration is None
+    assert result.ligands[0].protonated_at_ph == 7.4
+
+
+def test_run_sets_concentration_on_merged_primary() -> None:
+    """run() sets concentration when merging into the primary ligand (ligand= path)."""
+    ligand = Ligand.from_smiles("CCO", name="ethanol")
+    job = Protonation(ligand=ligand, ph=7.4)
+
+    mock_response = {
+        "jobOutputs": {
+            "smiles": "CCO",
+            "pH": 7.4,
+            "filter_percentage": 1,
+            "protonation_states": {
+                "smiles_list": ["OCC"],
+                "concentration_list": [99.93],
+            },
+        },
+    }
+    with patch.object(job, "_create_execution", return_value=mock_response):
+        result = job.run()
+
+    assert result.ligands[0] is ligand
+    assert ligand.protonation_concentration == pytest.approx(99.93)

--- a/tests/test_protonation_unit.py
+++ b/tests/test_protonation_unit.py
@@ -76,5 +76,3 @@ def test_protonation_make_payload_sync_flag() -> None:
     assert payload["sync"] is True
     assert payload["approveAmount"] == 0
     assert payload["inputs"]["ligand"]["smiles"] == "CCO"
-
-


### PR DESCRIPTION
## Summary

The platform protonation API already returns `concentration_list` alongside `smiles_list` in responses, but `Protonation.run()` was silently discarding it. This PR:

- Adds `protonation_concentration: float | None` field to the `Ligand` dataclass (next to the existing `protonated_at_ph`)
- Reads `concentration_list` from the API response and sets it on each returned `Ligand`
- Gracefully handles responses without `concentration_list` (older API versions)

### Why

We're migrating Balto's ADMET tools from local `molprops` to the platform SDK ([BALTO-245](https://deeporigin.atlassian.net/browse/BALTO-245)). The `ProtonationPredictor` is the last tool to migrate. Balto needs per-species population percentages for its user-facing text output (e.g. "CCO with concentration of 99.93%"). Without this field exposed, Balto would have to dig into raw `responses` to get data the platform already provides.

> **Note:** Balto also renders concentration-vs-pH curves (Henderson-Hasselbalch sweep), which requires pKa values the platform doesn't currently return. That's a separate, larger change — this PR covers the low-hanging fruit that already exists in the response.

## Test plan

- [x] `test_run_exposes_concentration_list` — verifies concentrations are set on both ligands in a multi-state response
- [x] `test_run_handles_missing_concentration_list` — verifies graceful fallback to `None` when key is absent
- [x] `test_run_sets_concentration_on_merged_primary` — verifies the `ligand=` path (merge into primary) also sets concentration

[BALTO-245]: https://deeporigin.atlassian.net/browse/BALTO-245?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ