### PR TITLE
DDOS-6831: feat: ability to use the enumerator tool

### DIFF
--- a/docs/dd/ref/enumerator.md
+++ b/docs/dd/ref/enumerator.md
@@ -1,0 +1,17 @@
+# `deeporigin.drug_discovery.enumerator`
+
+::: src.drug_discovery.enumerator
+    options:
+      docstring_style: google
+      show_root_heading: false
+      show_category_heading: true
+      show_object_full_path: false
+      show_root_toc_entry: false
+      inherited_members: true
+      members_order: alphabetical
+      filters:
+        - "!^_"  # Exclude private members (names starting with "_")
+      show_signature: true
+      show_signature_annotations: true
+      show_if_no_docstring: true
+      group_by_category: true

--- a/docs/dd/tools/enumerator.md
+++ b/docs/dd/tools/enumerator.md
@@ -1,0 +1,98 @@
+# Enumerator
+
+Generate analogue libraries from a parent [`Ligand`](../ref/ligand.md) using the
+Deep Origin Enumerator. `Enumerator` is a served tool: configure it with a single
+`job_type`, call `run()`, and get a `pandas.DataFrame` back.
+
+## Modes
+
+The tool exposes four `job_type` values:
+
+| `job_type` | What it does | Key inputs | Output |
+| --- | --- | --- | --- |
+| `SCAFFOLD` | MMP: grow a fragment at one attachment atom | `replace_ix` (one atom index) | products CSV |
+| `ANALOGUE` | MMP: swap a connected fragment | `replace_ix` (one or more indices) | products CSV |
+| `AVAILABLE_REACTIONS` | Discover named-reaction sites on the parent | none | reaction-site table |
+| `REACTION` | Enumerate products against the Enamine fragment library | `reaction_sites` | products CSV |
+
+`SCAFFOLD` and `ANALOGUE` are the two matched-molecular-pair (MMP) flavors, both
+backed by CReM. `AVAILABLE_REACTIONS` is a discovery step (it writes no CSV); its
+output feeds `REACTION`.
+
+## MMP enumeration (SCAFFOLD / ANALOGUE)
+
+MMP modes take explicit RDKit atom indices (`replace_ix`) marking the enumeration
+site. `SCAFFOLD` grows a new fragment at a single attachment atom; `ANALOGUE`
+replaces a connected fragment defined by one or more atom indices.
+
+```{.python notest}
+from deeporigin.drug_discovery import Enumerator, Ligand
+
+parent = Ligand.from_smiles("Brc1ccccc1")
+
+# Grow a fragment at atom 0
+scaffold = Enumerator(ligand=parent, job_type="SCAFFOLD", replace_ix=0)
+df = scaffold.run()
+df.head()
+```
+
+Tune the CReM search with `radius` (1-5) and `max_fragment_size` (1-15):
+
+```{.python notest}
+analogue = Enumerator(
+    ligand=parent,
+    job_type="ANALOGUE",
+    replace_ix=[0, 1],
+    radius=2,
+    max_fragment_size=8,
+)
+df = analogue.run()
+```
+
+The returned DataFrame is the descriptor-enriched `results.csv`: enumeration
+metadata columns plus RDKit descriptors (`molecular_weight`, `hbond_donor_count`,
+`hbond_acceptor_count`, `logp`, `tpsa`, `rotatable_bond_count`). After a run,
+`enumerator.cap_hit` indicates whether the platform enumeration cap was reached.
+
+## Reaction enumeration (AVAILABLE_REACTIONS then REACTION)
+
+Choosing valid reaction sites by hand is error-prone, so run `AVAILABLE_REACTIONS`
+first to discover them. Each row gives a `reaction_id`, `reaction_name`,
+`reactant_role`, and the `atom_indices` of the matched site.
+
+```{.python notest}
+sites = Enumerator(ligand=parent, job_type="AVAILABLE_REACTIONS").run()
+sites
+```
+
+Pick the rows you want and pass them verbatim as `reaction_sites` to a `REACTION`
+run:
+
+```{.python notest}
+df = Enumerator(
+    ligand=parent,
+    job_type="REACTION",
+    reaction_sites=[
+        {"reaction_id": "suzuki", "reactant_role": "core_halide", "atom_indices": [0, 1]},
+    ],
+).run()
+df.head()
+```
+
+`REACTION` accepts up to 16 sites. Each site must match a hit returned by
+`AVAILABLE_REACTIONS` on the same parent, otherwise the tool rejects the request.
+
+## Existing executions
+
+Reconstruct an `Enumerator` from an existing tools execution ID (for example to
+re-fetch results in a later session):
+
+```{.python notest}
+enum = Enumerator.from_id("<executionId>")
+df = enum.get_results()
+```
+
+If you already have the execution payload from `client.executions.get`, use
+`Enumerator.from_dto(dto)` instead.
+
+See the [API reference](../ref/enumerator.md) for the full signature.

--- a/docs/notebooks/clean/enumerator.ipynb
+++ b/docs/notebooks/clean/enumerator.ipynb
@@ -209,6 +209,14 @@
     "reloaded = Enumerator.from_id(reaction.id)\n",
     "reloaded.get_results().head()"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2f7e3f81-d66c-424e-8747-0d2fcdd2245e",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/docs/notebooks/clean/enumerator.ipynb
+++ b/docs/notebooks/clean/enumerator.ipynb
@@ -1,0 +1,221 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f6484198",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9d83188d",
+   "metadata": {},
+   "source": [
+    "# Enumerator\n",
+    "\n",
+    "The `Enumerator` served tool generates analogue libraries from a single parent `Ligand`. It supports four `job_type` values:\n",
+    "\n",
+    "- `SCAFFOLD` — MMP: grow a fragment at one attachment atom\n",
+    "- `ANALOGUE` — MMP: swap a connected fragment\n",
+    "- `AVAILABLE_REACTIONS` — discover named-reaction sites on the parent (no CSV)\n",
+    "- `REACTION` — enumerate products against the Enamine fragment library\n",
+    "\n",
+    "Every mode is configured in `__init__` and executed with a blocking `run()` that returns a `pandas.DataFrame`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "91bc72d2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from deeporigin.drug_discovery import Enumerator, Ligand\n",
+    "from deeporigin.platform import DeepOriginClient\n",
+    "\n",
+    "client = DeepOriginClient()\n",
+    "client"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "59d552f6",
+   "metadata": {},
+   "source": [
+    "## Create a parent ligand\n",
+    "\n",
+    "The enumerator takes a single parent `Ligand`. Its SMILES is sent inline; its optional `id` is echoed back as `parent_ligand_id` in the results. Here we use bromobenzene."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b6da524f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "parent = Ligand.from_smiles(\"Brc1ccccc1\")\n",
+    "parent"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c9ffc449",
+   "metadata": {},
+   "source": [
+    "## MMP mode 1: SCAFFOLD\n",
+    "\n",
+    "`SCAFFOLD` grows a new fragment at a single attachment atom. Pass the RDKit atom index as `replace_ix`. The result is a descriptor-enriched DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "154ad0e7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "scaffold = Enumerator(ligand=parent, job_type=\"SCAFFOLD\", replace_ix=3)\n",
+    "df = scaffold.run()\n",
+    "df.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "33f2c295",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Whether the run hit the platform enumeration cap\n",
+    "scaffold.cap_hit"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d27d5f2c",
+   "metadata": {},
+   "source": [
+    "## MMP mode 2: ANALOGUE\n",
+    "\n",
+    "`ANALOGUE` swaps out a connected fragment defined by one or more atom indices. Tune the CReM search with `radius` (1-5) and `max_fragment_size` (1-15)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "734e1eaf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "analogue = Enumerator(\n",
+    "    ligand=parent,\n",
+    "    job_type=\"ANALOGUE\",\n",
+    "    replace_ix=[3, 4],\n",
+    "    radius=2,\n",
+    "    max_fragment_size=8,\n",
+    ")\n",
+    "analogue.run().head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "84450ffe",
+   "metadata": {},
+   "source": [
+    "## Discovery: AVAILABLE_REACTIONS\n",
+    "\n",
+    "Choosing valid reaction sites by hand is error-prone, so run `AVAILABLE_REACTIONS` first. It returns one row per matched named-reaction site, with the `atom_indices` you feed into a `REACTION` run. This mode writes no CSV — the DataFrame is built from the inline result list."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1d69a121",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sites = Enumerator(ligand=parent, job_type=\"AVAILABLE_REACTIONS\").run()\n",
+    "sites"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f1bcbf0e",
+   "metadata": {},
+   "source": [
+    "## Enumeration: REACTION\n",
+    "\n",
+    "Pick the rows you want from the discovery table and pass them verbatim as `reaction_sites`. Each site must match a hit from `AVAILABLE_REACTIONS` on the same parent."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "571a755f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "suzuki_rows = sites[sites[\"reaction_id\"] == \"suzuki\"]\n",
+    "reaction_sites = [\n",
+    "    {\n",
+    "        \"reaction_id\": row[\"reaction_id\"],\n",
+    "        \"reactant_role\": row[\"reactant_role\"],\n",
+    "        \"atom_indices\": list(row[\"atom_indices\"]),\n",
+    "    }\n",
+    "    for _, row in suzuki_rows.iterrows()\n",
+    "]\n",
+    "reaction_sites"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bd50f527",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "reaction = Enumerator(\n",
+    "    ligand=parent,\n",
+    "    job_type=\"REACTION\",\n",
+    "    reaction_sites=reaction_sites,\n",
+    ")\n",
+    "df = reaction.run()\n",
+    "df.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "14972346",
+   "metadata": {},
+   "source": [
+    "## Reload an existing run\n",
+    "\n",
+    "Reconstruct an `Enumerator` from a tools execution ID and re-fetch its results without re-running."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "09b655a7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "reloaded = Enumerator.from_id(reaction.id)\n",
+    "reloaded.get_results().head()"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/drug_discovery/__init__.py
+++ b/src/drug_discovery/__init__.py
@@ -30,6 +30,7 @@ __all__ = [
     "Konnektor",
     "KonnektorResult",
     "Patent",
+    "Enumerator",
 ]
 
 DATA_DIR = files("deeporigin.data")
@@ -60,6 +61,7 @@ _LAZY_IMPORTS = {
     "Konnektor": ("deeporigin.drug_discovery.konnektor", "Konnektor"),
     "KonnektorResult": ("deeporigin.drug_discovery.konnektor", "KonnektorResult"),
     "Patent": ("deeporigin.drug_discovery.patent", "Patent"),
+    "Enumerator": ("deeporigin.drug_discovery.enumerator", "Enumerator"),
     "Execution": ("deeporigin.drug_discovery.execution", "Execution"),
     "PlatformStatus": ("deeporigin.platform.constants", "PlatformStatus"),
 }

--- a/src/drug_discovery/enumerator.py
+++ b/src/drug_discovery/enumerator.py
@@ -1,0 +1,498 @@
+"""Enumerator -- generate analogue libraries from a parent ligand (served, sync-only).
+
+Backed by the served platform tool ``deeporigin.enumerator`` (a ``direct``
+execution). One :class:`Enumerator` is configured with a single ``job_type`` and
+executed with a blocking :meth:`run`, which returns a :class:`pandas.DataFrame`.
+
+The tool exposes four ``job_type`` values:
+
+- ``SCAFFOLD`` -- CReM matched-molecular-pair (MMP) enumeration that grows a
+  fragment at a single attachment atom (one ``replace_ix`` index).
+- ``ANALOGUE`` -- CReM MMP enumeration that swaps a connected fragment (one or
+  more ``replace_ix`` indices forming a connected substructure).
+- ``AVAILABLE_REACTIONS`` -- discovers named-reaction sites on the parent and
+  returns their atom indices. Writes no CSV; the DataFrame is built from the
+  inline result list.
+- ``REACTION`` -- enumerates products against the Enamine fragment library at
+  explicit ``reaction_sites``. Each site must match a hit returned by a prior
+  ``AVAILABLE_REACTIONS`` run.
+
+``SCAFFOLD`` and ``ANALOGUE`` are the two MMP flavors.
+
+Usage::
+
+    from deeporigin.drug_discovery import Enumerator, Ligand
+
+    parent = Ligand.from_smiles("Brc1ccccc1")
+
+    # MMP: grow a fragment at atom 0
+    df = Enumerator(ligand=parent, job_type="SCAFFOLD", replace_ix=0).run()
+
+    # Discover reaction sites, then enumerate against them
+    sites = Enumerator(ligand=parent, job_type="AVAILABLE_REACTIONS").run()
+    df = Enumerator(
+        ligand=parent,
+        job_type="REACTION",
+        reaction_sites=[
+            {"reaction_id": "suzuki", "reactant_role": "core_halide", "atom_indices": [0, 1]},
+        ],
+    ).run()
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from typing import Any, Self
+
+from beartype import beartype
+import pandas as pd
+
+from deeporigin.drug_discovery.execution import Execution
+from deeporigin.drug_discovery.execution_mixins import SyncExecutableMixin
+from deeporigin.drug_discovery.structures.ligand import Ligand
+from deeporigin.exceptions import DeepOriginException
+from deeporigin.platform.client import DeepOriginClient
+from deeporigin.platform.constants import TOOL_KEYS_AND_VERSIONS, is_success_status
+from deeporigin.utils.constants import (
+    ENUMERATOR_AVAILABLE_REACTIONS_COLUMNS,
+    ENUMERATOR_JOB_TYPES,
+    ENUMERATOR_MAX_FRAGMENT_SIZE_MAX,
+    ENUMERATOR_MAX_FRAGMENT_SIZE_MIN,
+    ENUMERATOR_MAX_REACTION_SITES,
+    ENUMERATOR_MMP_JOB_TYPES,
+    ENUMERATOR_RADIUS_MAX,
+    ENUMERATOR_RADIUS_MIN,
+)
+
+_DEFAULT_MAX_FRAGMENT_SIZE = 10
+
+
+def _normalize_replace_ix(replace_ix: int | list[int] | None) -> list[int] | None:
+    """Normalize ``replace_ix`` to a list of atom indices (or ``None``).
+
+    Args:
+        replace_ix: A single atom index, a list of atom indices, or ``None``.
+
+    Returns:
+        A list of atom indices, or ``None`` when ``replace_ix`` is ``None``.
+    """
+    if replace_ix is None:
+        return None
+    if isinstance(replace_ix, int):
+        return [replace_ix]
+    return list(replace_ix)
+
+
+class Enumerator(Execution, SyncExecutableMixin):
+    """Enumerate analogues of a parent ligand via the served enumerator tool.
+
+    Configure the instance with a parent :class:`~deeporigin.drug_discovery.structures.ligand.Ligand`,
+    a ``job_type``, and its mode-specific parameters, then call :meth:`run` to
+    execute synchronously and receive a :class:`pandas.DataFrame`.
+
+    For ``SCAFFOLD`` / ``ANALOGUE`` / ``REACTION`` the DataFrame is parsed from
+    the tool's descriptor-enriched ``results.csv``. For ``AVAILABLE_REACTIONS``
+    the DataFrame is built from the inline ``available_reactions`` list (no CSV
+    is written).
+
+    Attributes:
+        ligand: Parent ligand whose ``smiles`` (and optional ``id``) is enumerated.
+        job_type: One of ``SCAFFOLD``, ``ANALOGUE``, ``AVAILABLE_REACTIONS``, ``REACTION``.
+        replace_ix: RDKit atom indices marking the MMP enumeration site (MMP modes).
+        reaction_sites: Named-reaction sites for REACTION enumeration.
+        radius: CReM environment radius (MMP modes).
+        max_fragment_size: Maximum heavy atoms in the added/replacement fragment (MMP modes).
+        cap_hit: Whether the last run hit the platform enumeration cap (MMP/REACTION),
+            or ``None`` before a run or for ``AVAILABLE_REACTIONS``.
+    """
+
+    tool_key: str = TOOL_KEYS_AND_VERSIONS["enumerator"]["tool_key"]
+
+    @beartype
+    def __init__(
+        self,
+        *,
+        ligand: Ligand,
+        job_type: str,
+        replace_ix: int | list[int] | None = None,
+        reaction_sites: list[dict[str, Any]] | None = None,
+        radius: int = ENUMERATOR_RADIUS_MIN,
+        max_fragment_size: int = _DEFAULT_MAX_FRAGMENT_SIZE,
+        tool_version: str = TOOL_KEYS_AND_VERSIONS["enumerator"]["tool_version"],
+        client: DeepOriginClient | None = None,
+    ) -> None:
+        """Configure an enumerator run for a single parent ligand.
+
+        Args:
+            ligand: Parent ligand. Its ``smiles`` is sent inline; its ``id`` (when
+                set) is echoed back as ``parent_ligand_id`` in the results.
+            job_type: Enumeration mode; one of :data:`~deeporigin.utils.constants.ENUMERATOR_JOB_TYPES`.
+            replace_ix: RDKit atom index (or indices) marking the enumeration site.
+                Required for ``SCAFFOLD`` (exactly one) and ``ANALOGUE`` (one or more,
+                forming a connected substructure). Not used for the reaction modes.
+            reaction_sites: List of ``{reaction_id, reactant_role, atom_indices}``
+                dicts. Required for ``REACTION``; take these verbatim from an
+                ``AVAILABLE_REACTIONS`` run. Not used for the MMP modes.
+            radius: CReM environment radius for MMP modes (1-5). Defaults to 1.
+            max_fragment_size: Maximum heavy atoms in the added/replacement fragment
+                for MMP modes (1-15). Defaults to 10.
+            tool_version: Platform tool version to run. Settable so callers can pin
+                or upgrade independently of the SDK release.
+            client: Optional API client. Uses the default if not provided.
+
+        Raises:
+            ValueError: If ``job_type`` is unknown, required mode inputs are missing
+                or malformed, or numeric bounds are exceeded.
+        """
+        super().__init__(client=client)
+        self.tool_version = tool_version
+        self._ligand = ligand
+        self._job_type = job_type
+        self._replace_ix = _normalize_replace_ix(replace_ix)
+        self._reaction_sites = reaction_sites
+        self._radius = radius
+        self._max_fragment_size = max_fragment_size
+        self._cap_hit: bool | None = None
+        self._validate()
+
+    def _validate(self) -> None:
+        """Validate the configured inputs for the selected ``job_type``.
+
+        Raises:
+            ValueError: If any input is invalid for the selected mode.
+        """
+        if self._job_type not in ENUMERATOR_JOB_TYPES:
+            raise ValueError(
+                f"Unknown job_type {self._job_type!r}. "
+                f"Allowed: {sorted(ENUMERATOR_JOB_TYPES)}"
+            )
+        if not self._ligand.smiles:
+            raise ValueError("Enumerator requires a ligand with a SMILES string.")
+        if not (ENUMERATOR_RADIUS_MIN <= self._radius <= ENUMERATOR_RADIUS_MAX):
+            raise ValueError(
+                f"radius must be between {ENUMERATOR_RADIUS_MIN} and "
+                f"{ENUMERATOR_RADIUS_MAX}, got {self._radius}."
+            )
+        if not (
+            ENUMERATOR_MAX_FRAGMENT_SIZE_MIN
+            <= self._max_fragment_size
+            <= ENUMERATOR_MAX_FRAGMENT_SIZE_MAX
+        ):
+            raise ValueError(
+                f"max_fragment_size must be between {ENUMERATOR_MAX_FRAGMENT_SIZE_MIN} "
+                f"and {ENUMERATOR_MAX_FRAGMENT_SIZE_MAX}, got {self._max_fragment_size}."
+            )
+
+        if self._job_type in ENUMERATOR_MMP_JOB_TYPES:
+            self._validate_mmp()
+        elif self._job_type == "REACTION":
+            self._validate_reaction()
+        else:  # AVAILABLE_REACTIONS
+            if self._replace_ix is not None or self._reaction_sites is not None:
+                raise ValueError(
+                    "AVAILABLE_REACTIONS takes only a ligand; "
+                    "replace_ix and reaction_sites are not allowed."
+                )
+
+    def _validate_mmp(self) -> None:
+        """Validate ``replace_ix`` for the MMP modes (SCAFFOLD / ANALOGUE)."""
+        if self._reaction_sites is not None:
+            raise ValueError(
+                f"reaction_sites is not allowed for job_type {self._job_type!r}."
+            )
+        if not self._replace_ix:
+            raise ValueError(
+                f"job_type {self._job_type!r} requires replace_ix (atom indices)."
+            )
+        if any(ix < 0 for ix in self._replace_ix):
+            raise ValueError("replace_ix values must be non-negative atom indices.")
+        if self._job_type == "SCAFFOLD" and len(self._replace_ix) != 1:
+            raise ValueError(
+                "SCAFFOLD requires exactly one replace_ix (the attachment atom)."
+            )
+
+    def _validate_reaction(self) -> None:
+        """Validate ``reaction_sites`` for the REACTION mode."""
+        if self._replace_ix is not None:
+            raise ValueError("replace_ix is not allowed for job_type 'REACTION'.")
+        if not self._reaction_sites:
+            raise ValueError("REACTION requires a non-empty reaction_sites list.")
+        if len(self._reaction_sites) > ENUMERATOR_MAX_REACTION_SITES:
+            raise ValueError(
+                f"reaction_sites accepts at most {ENUMERATOR_MAX_REACTION_SITES} "
+                f"entries, got {len(self._reaction_sites)}."
+            )
+        for site in self._reaction_sites:
+            reaction_id = site.get("reaction_id")
+            reactant_role = site.get("reactant_role")
+            atom_indices = site.get("atom_indices")
+            if not isinstance(reaction_id, str) or not reaction_id:
+                raise ValueError("Each reaction site needs a non-empty reaction_id.")
+            if not isinstance(reactant_role, str) or not reactant_role:
+                raise ValueError("Each reaction site needs a non-empty reactant_role.")
+            if (
+                not isinstance(atom_indices, list)
+                or not atom_indices
+                or not all(isinstance(i, int) for i in atom_indices)
+            ):
+                raise ValueError(
+                    "Each reaction site needs a non-empty atom_indices list of ints."
+                )
+
+    @property
+    def ligand(self) -> Ligand:
+        """Parent ligand targeted by this enumeration (read-only)."""
+        return self._ligand
+
+    @property
+    def job_type(self) -> str:
+        """Enumeration mode for this run (read-only)."""
+        return self._job_type
+
+    @property
+    def replace_ix(self) -> list[int] | None:
+        """RDKit atom indices marking the MMP enumeration site, if any (read-only)."""
+        return list(self._replace_ix) if self._replace_ix is not None else None
+
+    @property
+    def reaction_sites(self) -> list[dict[str, Any]] | None:
+        """Named-reaction sites for REACTION enumeration, if any (read-only)."""
+        return self._reaction_sites
+
+    @property
+    def radius(self) -> int:
+        """CReM environment radius used for MMP modes (read-only)."""
+        return self._radius
+
+    @property
+    def max_fragment_size(self) -> int:
+        """Maximum heavy atoms in the added/replacement fragment (MMP modes, read-only)."""
+        return self._max_fragment_size
+
+    @property
+    def cap_hit(self) -> bool | None:
+        """Whether the last MMP/REACTION run hit the platform enumeration cap.
+
+        ``None`` before :meth:`run`, or for ``AVAILABLE_REACTIONS`` (which has no cap).
+        """
+        return self._cap_hit
+
+    def __repr__(self) -> str:
+        """Return a concise summary of this Enumerator."""
+        parts = [f"Enumerator job_type={self._job_type!r}"]
+        if self._ligand.id is not None:
+            parts.append(f"ligand_id={self._ligand.id!r}")
+        if self.id:
+            parts.append(f"id={self.id!r}")
+        status = getattr(self, "status", None)
+        if status:
+            parts.append(f"status={status!r}")
+        return f"<{' '.join(parts)}>"
+
+    def _make_payload(
+        self,
+        *,
+        approve_amount: int | None = None,
+        sync: bool = True,
+    ) -> dict[str, Any]:
+        """Build the POST body for ``executions.create``.
+
+        The enumerator input schema forbids unknown properties, so ``sync`` is
+        sent as a top-level body field (like molprops / system-prep) rather than
+        inside ``inputs``.
+
+        Args:
+            approve_amount: Spend cap forwarded as ``approveAmount`` when set.
+            sync: ``True`` for blocking (direct) execution.
+
+        Returns:
+            Payload dict for ``executions.create``.
+        """
+        ligand_input: dict[str, Any] = {"smiles": self._ligand.smiles}
+        if self._ligand.id is not None:
+            ligand_input["id"] = self._ligand.id
+
+        inputs: dict[str, Any] = {
+            "ligand": ligand_input,
+            "job_type": self._job_type,
+        }
+        if self._job_type in ENUMERATOR_MMP_JOB_TYPES:
+            inputs["replace_ix"] = list(self._replace_ix or [])
+            inputs["radius"] = self._radius
+            inputs["max_fragment_size"] = self._max_fragment_size
+        elif self._job_type == "REACTION":
+            inputs["reaction_sites"] = [
+                {
+                    "reaction_id": site["reaction_id"],
+                    "reactant_role": site["reactant_role"],
+                    "atom_indices": list(site["atom_indices"]),
+                }
+                for site in (self._reaction_sites or [])
+            ]
+
+        payload: dict[str, Any] = {
+            "inputs": inputs,
+            "outputs": {},
+            "metadata": {},
+            "sync": sync,
+        }
+        if approve_amount is not None:
+            payload["approveAmount"] = approve_amount
+        return payload
+
+    @beartype
+    def run(self) -> pd.DataFrame:
+        """Execute the enumeration synchronously (blocking) and return a DataFrame.
+
+        Submits one synchronous execution (``sync=True``), applies the response
+        via :meth:`~deeporigin.drug_discovery.execution.Execution.update_from_dto`,
+        and returns results via :meth:`get_results`.
+
+        Returns:
+            A :class:`pandas.DataFrame`. For ``SCAFFOLD`` / ``ANALOGUE`` /
+            ``REACTION`` it is the descriptor-enriched ``results.csv``; for
+            ``AVAILABLE_REACTIONS`` it has columns
+            :data:`~deeporigin.utils.constants.ENUMERATOR_AVAILABLE_REACTIONS_COLUMNS`.
+
+        Raises:
+            DeepOriginException: If the execution did not complete successfully or
+                no results could be parsed.
+        """
+        dto = self._create_execution(data=self._make_payload(sync=True))
+        self.update_from_dto(dto)
+
+        if not is_success_status(self.status):
+            raise DeepOriginException(
+                title="Enumeration did not complete",
+                message=(
+                    f"Enumerator execution ended in {self.status!r} state "
+                    f"(execution id {self.id!r})."
+                ),
+            )
+
+        return self.get_results(dto)
+
+    @beartype
+    def get_results(self, dto: dict[str, Any] | None = None) -> pd.DataFrame:
+        """Return this execution's results as a :class:`pandas.DataFrame`.
+
+        Reads ``jobOutputs`` from ``dto`` (or fetches it via
+        ``client.executions.get`` when omitted, e.g. after
+        :meth:`~deeporigin.drug_discovery.execution.Execution.from_id`).
+
+        Args:
+            dto: Optional execution payload from ``executions.create`` /
+                ``executions.get``. Passing it avoids an extra GET.
+
+        Returns:
+            A DataFrame of enumeration products (MMP / REACTION) or discovered
+            reaction sites (AVAILABLE_REACTIONS).
+
+        Raises:
+            ValueError: If :attr:`id` is unset.
+            DeepOriginException: If no results could be parsed.
+        """
+        exec_id = self._ensure_id()
+        if dto is None:
+            dto = self.client.executions.get(exec_id)  # ty:ignore[unresolved-attribute]
+        job_outputs = dto.get("jobOutputs") if isinstance(dto, dict) else None
+        if not isinstance(job_outputs, dict):
+            job_outputs = {}
+
+        if self._job_type == "AVAILABLE_REACTIONS":
+            return self._available_reactions_dataframe(job_outputs)
+        return self._enumeration_results_dataframe(job_outputs)
+
+    @staticmethod
+    def _available_reactions_dataframe(job_outputs: dict[str, Any]) -> pd.DataFrame:
+        """Build a DataFrame of discovered reaction sites from ``jobOutputs``."""
+        rows = [
+            row
+            for row in (job_outputs.get("available_reactions") or [])
+            if isinstance(row, dict)
+        ]
+        columns = list(ENUMERATOR_AVAILABLE_REACTIONS_COLUMNS)
+        if not rows:
+            return pd.DataFrame({column: [] for column in columns})
+        df = pd.DataFrame(rows)
+        ordered = [c for c in columns if c in df.columns]
+        extra = [c for c in df.columns if c not in ordered]
+        return df[ordered + extra]
+
+    def _enumeration_results_dataframe(
+        self, job_outputs: dict[str, Any]
+    ) -> pd.DataFrame:
+        """Download and parse the enumerator ``results.csv`` into a DataFrame."""
+        results = [
+            row
+            for row in (job_outputs.get("enumeration_results") or [])
+            if isinstance(row, dict)
+        ]
+        if not results:
+            raise DeepOriginException(
+                title="No enumeration results",
+                message="The execution returned no enumeration_results.",
+            )
+        first = results[0]
+        csv_path = first.get("csv_file_path")
+        if not csv_path:
+            raise DeepOriginException(
+                title="No results CSV",
+                message="enumeration_results is missing csv_file_path.",
+            )
+        self._cap_hit = bool(first.get("cap_hit", False))
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            local_path = os.path.join(tmpdir, "results.csv")
+            self.client.files.download(
+                remote_path=csv_path,
+                local_path=local_path,
+            )
+            return pd.read_csv(local_path)
+
+    @classmethod
+    def from_dto(
+        cls,
+        dto: dict[str, Any],
+        *,
+        client: DeepOriginClient | None = None,
+    ) -> Self:
+        """Construct an ``Enumerator`` from a tools execution DTO.
+
+        Rehydrates the parent ligand and mode-specific inputs from ``userInputs``
+        (falling back to ``inputs`` for older payloads).
+
+        Args:
+            dto: Execution payload (same shape as ``client.executions.get``).
+            client: Optional API client. Uses the default if not provided.
+
+        Returns:
+            An ``Enumerator`` with ``id``, pricing fields, and domain inputs set.
+
+        Raises:
+            ValueError: If the stored inputs are missing a ligand SMILES.
+        """
+        instance = super().from_dto(dto, client=client)
+        inputs: dict[str, Any] = dto.get("userInputs") or dto.get("inputs") or {}
+
+        ligand_in = inputs.get("ligand") or {}
+        smiles = ligand_in.get("smiles")
+        if not smiles:
+            raise ValueError(
+                "Cannot rehydrate Enumerator: stored inputs have no ligand SMILES."
+            )
+        ligand = Ligand.from_smiles(str(smiles))
+        if ligand_in.get("id") is not None:
+            ligand.id = str(ligand_in["id"])
+
+        instance._ligand = ligand
+        instance._job_type = str(inputs.get("job_type") or "")
+        instance._replace_ix = _normalize_replace_ix(inputs.get("replace_ix"))
+        instance._reaction_sites = inputs.get("reaction_sites")
+        instance._radius = int(inputs.get("radius", ENUMERATOR_RADIUS_MIN))
+        instance._max_fragment_size = int(
+            inputs.get("max_fragment_size", _DEFAULT_MAX_FRAGMENT_SIZE)
+        )
+        instance._cap_hit = None
+        return instance

--- a/src/drug_discovery/enumerator.py
+++ b/src/drug_discovery/enumerator.py
@@ -169,6 +169,24 @@ class Enumerator(Execution, SyncExecutableMixin):
             )
         if not self._ligand.smiles:
             raise ValueError("Enumerator requires a ligand with a SMILES string.")
+
+        if self._job_type in ENUMERATOR_MMP_JOB_TYPES:
+            self._validate_mmp()
+        elif self._job_type == "REACTION":
+            self._validate_reaction()
+        else:  # AVAILABLE_REACTIONS
+            if self._replace_ix is not None or self._reaction_sites is not None:
+                raise ValueError(
+                    "AVAILABLE_REACTIONS takes only a ligand; "
+                    "replace_ix and reaction_sites are not allowed."
+                )
+
+    def _validate_mmp(self) -> None:
+        """Validate ``replace_ix`` and numeric bounds for MMP modes (SCAFFOLD / ANALOGUE).
+
+        ``radius`` and ``max_fragment_size`` only affect the MMP payload, so their
+        bounds are enforced here rather than for every ``job_type``.
+        """
         if not (ENUMERATOR_RADIUS_MIN <= self._radius <= ENUMERATOR_RADIUS_MAX):
             raise ValueError(
                 f"radius must be between {ENUMERATOR_RADIUS_MIN} and "
@@ -183,20 +201,6 @@ class Enumerator(Execution, SyncExecutableMixin):
                 f"max_fragment_size must be between {ENUMERATOR_MAX_FRAGMENT_SIZE_MIN} "
                 f"and {ENUMERATOR_MAX_FRAGMENT_SIZE_MAX}, got {self._max_fragment_size}."
             )
-
-        if self._job_type in ENUMERATOR_MMP_JOB_TYPES:
-            self._validate_mmp()
-        elif self._job_type == "REACTION":
-            self._validate_reaction()
-        else:  # AVAILABLE_REACTIONS
-            if self._replace_ix is not None or self._reaction_sites is not None:
-                raise ValueError(
-                    "AVAILABLE_REACTIONS takes only a ligand; "
-                    "replace_ix and reaction_sites are not allowed."
-                )
-
-    def _validate_mmp(self) -> None:
-        """Validate ``replace_ix`` for the MMP modes (SCAFFOLD / ANALOGUE)."""
         if self._reaction_sites is not None:
             raise ValueError(
                 f"reaction_sites is not allowed for job_type {self._job_type!r}."
@@ -471,7 +475,8 @@ class Enumerator(Execution, SyncExecutableMixin):
             An ``Enumerator`` with ``id``, pricing fields, and domain inputs set.
 
         Raises:
-            ValueError: If the stored inputs are missing a ligand SMILES.
+            ValueError: If the stored inputs are missing a ligand SMILES or carry
+                a missing/unknown ``job_type``.
         """
         instance = super().from_dto(dto, client=client)
         inputs: dict[str, Any] = dto.get("userInputs") or dto.get("inputs") or {}
@@ -486,8 +491,15 @@ class Enumerator(Execution, SyncExecutableMixin):
         if ligand_in.get("id") is not None:
             ligand.id = str(ligand_in["id"])
 
+        job_type = str(inputs.get("job_type") or "")
+        if job_type not in ENUMERATOR_JOB_TYPES:
+            raise ValueError(
+                "Cannot rehydrate Enumerator: stored inputs have an unknown "
+                f"job_type {job_type!r}. Allowed: {sorted(ENUMERATOR_JOB_TYPES)}"
+            )
+
         instance._ligand = ligand
-        instance._job_type = str(inputs.get("job_type") or "")
+        instance._job_type = job_type
         instance._replace_ix = _normalize_replace_ix(inputs.get("replace_ix"))
         instance._reaction_sites = inputs.get("reaction_sites")
         instance._radius = int(inputs.get("radius", ENUMERATOR_RADIUS_MIN))

--- a/src/platform/constants.py
+++ b/src/platform/constants.py
@@ -138,4 +138,8 @@ TOOL_KEYS_AND_VERSIONS: dict[str, dict[str, str]] = {
         "tool_key": "deeporigin.draco",
         "tool_version": "latest",
     },
+    "enumerator": {
+        "tool_key": "deeporigin.enumerator",
+        "tool_version": "latest",
+    },
 }

--- a/src/utils/constants.py
+++ b/src/utils/constants.py
@@ -153,3 +153,65 @@ notebook cell until the execution reaches a terminal state. Used by doc notebook
 
 PROGRESS_TREE_DISPLAY_ACRONYMS: frozenset[str] = frozenset({"abfe", "rbfe"})
 """Workflow step tokens uppercased in progress-tree node labels (e.g. RBFE, ABFE)."""
+
+ENUMERATOR_JOB_TYPES: frozenset[str] = frozenset(
+    {"SCAFFOLD", "ANALOGUE", "AVAILABLE_REACTIONS", "REACTION"}
+)
+"""Valid ``job_type`` values for ``deeporigin.enumerator``.
+
+``SCAFFOLD`` and ``ANALOGUE`` are the two CReM matched-molecular-pair (MMP)
+flavors; ``AVAILABLE_REACTIONS`` discovers named-reaction sites; ``REACTION``
+enumerates products against the Enamine fragment library."""
+
+ENUMERATOR_MMP_JOB_TYPES: frozenset[str] = frozenset({"SCAFFOLD", "ANALOGUE"})
+"""``job_type`` values that run CReM MMP enumeration (require ``replace_ix``)."""
+
+ENUMERATOR_RADIUS_MIN = 1
+"""Minimum CReM environment ``radius`` accepted by the enumerator (MMP modes)."""
+
+ENUMERATOR_RADIUS_MAX = 5
+"""Maximum CReM environment ``radius`` accepted by the enumerator (MMP modes)."""
+
+ENUMERATOR_MAX_FRAGMENT_SIZE_MIN = 1
+"""Minimum ``max_fragment_size`` accepted by the enumerator (MMP modes)."""
+
+ENUMERATOR_MAX_FRAGMENT_SIZE_MAX = 15
+"""Maximum ``max_fragment_size`` accepted by the enumerator (MMP modes)."""
+
+ENUMERATOR_MAX_REACTION_SITES = 16
+"""Maximum number of ``reaction_sites`` accepted per REACTION enumeration."""
+
+ENUMERATOR_RESULTS_CSV_COLUMNS: tuple[str, ...] = (
+    "row_id",
+    "smiles",
+    "parent_smiles",
+    "enumeration_mode",
+    "parent_ligand_id",
+    "job_type",
+    "replace_ix",
+    "radius",
+    "max_fragment_size",
+    "reaction_id",
+    "reactant_role",
+    "atom_indices",
+    "building_block_id",
+)
+"""Base column order of the enumerator ``results.csv`` (before RDKit descriptors)."""
+
+ENUMERATOR_RDKIT_DESCRIPTOR_COLUMNS: tuple[str, ...] = (
+    "molecular_weight",
+    "hbond_donor_count",
+    "hbond_acceptor_count",
+    "logp",
+    "tpsa",
+    "rotatable_bond_count",
+)
+"""RDKit descriptor columns appended to the enumerator ``results.csv``."""
+
+ENUMERATOR_AVAILABLE_REACTIONS_COLUMNS: tuple[str, ...] = (
+    "reaction_id",
+    "reaction_name",
+    "reactant_role",
+    "atom_indices",
+)
+"""Column order for the DataFrame built from AVAILABLE_REACTIONS ``jobOutputs``."""

--- a/tests/mock_server/routers/tools.py
+++ b/tests/mock_server/routers/tools.py
@@ -1073,6 +1073,136 @@ def create_tools_router(
 
         return execution
 
+    def _synthesize_available_reactions(smiles: str) -> list[dict[str, Any]]:
+        """Return deterministic AVAILABLE_REACTIONS hits for a parent SMILES."""
+        return [
+            {
+                "reaction_id": "suzuki",
+                "reaction_name": "Suzuki Coupling",
+                "reactant_role": "core_halide",
+                "atom_indices": [0, 1],
+            },
+            {
+                "reaction_id": "buchwald_hartwig",
+                "reaction_name": "Buchwald-Hartwig",
+                "reactant_role": "core_halide",
+                "atom_indices": [0, 1],
+            },
+        ]
+
+    def _synthesize_enumerator_csv(
+        *,
+        job_type: str,
+        inputs: dict[str, Any],
+        smiles: str,
+        parent_ligand_id: str,
+    ) -> str:
+        """Build a descriptor-enriched enumerator ``results.csv`` for MMP / REACTION."""
+        import csv
+        import io
+
+        from deeporigin.utils.constants import (
+            ENUMERATOR_RDKIT_DESCRIPTOR_COLUMNS,
+            ENUMERATOR_RESULTS_CSV_COLUMNS,
+        )
+
+        columns = list(ENUMERATOR_RESULTS_CSV_COLUMNS) + list(
+            ENUMERATOR_RDKIT_DESCRIPTOR_COLUMNS
+        )
+        is_reaction = job_type == "REACTION"
+        enumeration_mode = "REACTION" if is_reaction else "MMP"
+        reaction_sites = inputs.get("reaction_sites") or []
+        first_site = reaction_sites[0] if reaction_sites else {}
+        products = (
+            ["c1ccc(-c2ccccc2)cc1", "c1ccc(-c2ccncc2)cc1"]
+            if is_reaction
+            else ["Cc1ccccc1", "CCc1ccccc1"]
+        )
+
+        rows: list[dict[str, Any]] = []
+        for i, product in enumerate(products, start=1):
+            row: dict[str, Any] = {c: "" for c in columns}
+            row["row_id"] = i
+            row["smiles"] = product
+            row["parent_smiles"] = smiles
+            row["enumeration_mode"] = enumeration_mode
+            row["parent_ligand_id"] = parent_ligand_id
+            row["job_type"] = job_type
+            if is_reaction:
+                row["reaction_id"] = first_site.get("reaction_id", "")
+                row["reactant_role"] = first_site.get("reactant_role", "")
+                row["atom_indices"] = json.dumps(first_site.get("atom_indices", []))
+                row["building_block_id"] = f"EN300-{i:04d}"
+            else:
+                row["replace_ix"] = json.dumps(inputs.get("replace_ix", []))
+                row["radius"] = inputs.get("radius", 1)
+                row["max_fragment_size"] = inputs.get("max_fragment_size", 10)
+            descriptor_values = {
+                "molecular_weight": round(92.14 + i, 3),
+                "hbond_donor_count": 0,
+                "hbond_acceptor_count": 0,
+                "logp": round(1.5 + i * 0.1, 3),
+                "tpsa": 0.0,
+                "rotatable_bond_count": i,
+            }
+            for key, value in descriptor_values.items():
+                row[key] = value
+            rows.append(row)
+
+        buffer = io.StringIO()
+        writer = csv.DictWriter(buffer, fieldnames=columns)
+        writer.writeheader()
+        writer.writerows(rows)
+        return buffer.getvalue()
+
+    def _build_enumerator_execution(
+        *, org_key: str, tool_key: str, tool_version: str, body: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Build a synchronous ``deeporigin.enumerator`` execution DTO.
+
+        For ``AVAILABLE_REACTIONS`` it returns inline ``available_reactions`` and
+        writes no CSV. For the MMP modes (``SCAFFOLD`` / ``ANALOGUE``) and
+        ``REACTION`` it writes a descriptor-enriched ``results.csv`` into the
+        mock file store and returns an ``enumeration_results`` row pointing at it.
+        """
+        execution = _create_blocking_run_dto(
+            org_key=org_key,
+            tool_key=tool_key,
+            tool_version=tool_version,
+            body=body,
+        )
+        eid = execution["executionId"]
+        inputs = body.get("inputs", {}) or {}
+        job_type = str(inputs.get("job_type") or "")
+        ligand_in = inputs.get("ligand") or {}
+        smiles = str(ligand_in.get("smiles") or "")
+        parent_ligand_id = str(ligand_in.get("id") or "")
+
+        if job_type == "AVAILABLE_REACTIONS":
+            execution["jobOutputs"] = {
+                "available_reactions": _synthesize_available_reactions(smiles),
+            }
+            return execution
+
+        csv_text = _synthesize_enumerator_csv(
+            job_type=job_type,
+            inputs=inputs,
+            smiles=smiles,
+            parent_ligand_id=parent_ligand_id,
+        )
+        csv_path = f"tool-runs/{eid}/results.csv"
+        file_storage[csv_path] = csv_text.encode("utf-8")
+
+        row: dict[str, Any] = {
+            "parent_smiles": smiles,
+            "cap_hit": False,
+            "csv_file_path": csv_path,
+        }
+        if parent_ligand_id:
+            row["parent_ligand_id"] = parent_ligand_id
+        execution["jobOutputs"] = {"enumeration_results": [row]}
+        return execution
+
     def _inject_result_explorer_records_from_outputs(
         *,
         tool_key: str,
@@ -1842,6 +1972,15 @@ def create_tools_router(
                 }
                 executions[execution["executionId"]] = execution
                 return _normalize_execution(execution)
+        if tool_key == "deeporigin.enumerator" and body.get("sync") is True:
+            execution = _build_enumerator_execution(
+                org_key=org_key,
+                tool_key=tool_key,
+                tool_version=tool_version,
+                body=body,
+            )
+            executions[execution["executionId"]] = execution
+            return _normalize_execution(execution)
         if tool_key == "deeporigin.mol-props-protonation":
             execution = _build_protonation_execution(
                 org_key=org_key,

--- a/tests/test_enumerator_local.py
+++ b/tests/test_enumerator_local.py
@@ -1,0 +1,288 @@
+"""Local mock-server tests for :class:`~deeporigin.drug_discovery.enumerator.Enumerator`."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pandas as pd
+import pytest
+
+from deeporigin.drug_discovery import Enumerator, Ligand
+from deeporigin.platform.constants import TOOL_KEYS_AND_VERSIONS
+from deeporigin.utils.constants import (
+    ENUMERATOR_AVAILABLE_REACTIONS_COLUMNS,
+    ENUMERATOR_RDKIT_DESCRIPTOR_COLUMNS,
+    ENUMERATOR_RESULTS_CSV_COLUMNS,
+)
+from tests.conftest import check_tool_exists
+
+if TYPE_CHECKING:
+    from deeporigin.platform.client import DeepOriginClient
+
+_PARENT_SMILES = "Brc1ccccc1"
+_SUZUKI_SITE = {
+    "reaction_id": "suzuki",
+    "reactant_role": "core_halide",
+    "atom_indices": [0, 1],
+}
+
+
+def _assert_tool_available(client: DeepOriginClient) -> None:
+    """Skip-safe check that the enumerator tool is registered."""
+    cfg = TOOL_KEYS_AND_VERSIONS["enumerator"]
+    assert check_tool_exists(client, cfg["tool_key"], cfg["tool_version"])
+
+
+# -- run() end-to-end (mock server) -------------------------------------------
+
+
+def test_enumerator_scaffold_run_returns_dataframe(client: DeepOriginClient) -> None:
+    """SCAFFOLD run returns a descriptor-enriched DataFrame in MMP mode."""
+    _assert_tool_available(client)
+    parent = Ligand.from_smiles(_PARENT_SMILES)
+    enum = Enumerator(ligand=parent, job_type="SCAFFOLD", replace_ix=3, client=client)
+
+    df = enum.run()
+
+    assert isinstance(df, pd.DataFrame)
+    assert not df.empty
+    for column in ENUMERATOR_RESULTS_CSV_COLUMNS:
+        assert column in df.columns
+    for column in ENUMERATOR_RDKIT_DESCRIPTOR_COLUMNS:
+        assert column in df.columns
+    assert set(df["enumeration_mode"]) == {"MMP"}
+    assert set(df["job_type"]) == {"SCAFFOLD"}
+    assert enum.status == "Completed"
+    assert enum.id is not None
+    assert enum.cap_hit is False
+
+
+def test_enumerator_analogue_run_returns_dataframe(client: DeepOriginClient) -> None:
+    """ANALOGUE accepts multiple replace_ix and returns a DataFrame."""
+    _assert_tool_available(client)
+    parent = Ligand.from_smiles(_PARENT_SMILES)
+    enum = Enumerator(
+        ligand=parent,
+        job_type="ANALOGUE",
+        replace_ix=[3, 4],
+        client=client,
+    )
+
+    df = enum.run()
+
+    assert isinstance(df, pd.DataFrame)
+    assert not df.empty
+    assert set(df["job_type"]) == {"ANALOGUE"}
+
+
+def test_enumerator_available_reactions_returns_dataframe(
+    client: DeepOriginClient,
+) -> None:
+    """AVAILABLE_REACTIONS returns the reaction-site DataFrame (no CSV)."""
+    _assert_tool_available(client)
+    parent = Ligand.from_smiles(_PARENT_SMILES)
+    enum = Enumerator(ligand=parent, job_type="AVAILABLE_REACTIONS", client=client)
+
+    df = enum.run()
+
+    assert isinstance(df, pd.DataFrame)
+    assert not df.empty
+    assert list(df.columns[: len(ENUMERATOR_AVAILABLE_REACTIONS_COLUMNS)]) == list(
+        ENUMERATOR_AVAILABLE_REACTIONS_COLUMNS
+    )
+    assert "suzuki" in set(df["reaction_id"])
+    assert enum.cap_hit is None
+
+
+def test_enumerator_reaction_run_returns_dataframe(client: DeepOriginClient) -> None:
+    """REACTION enumerates against explicit reaction sites and returns a DataFrame."""
+    _assert_tool_available(client)
+    parent = Ligand.from_smiles(_PARENT_SMILES)
+    enum = Enumerator(
+        ligand=parent,
+        job_type="REACTION",
+        reaction_sites=[_SUZUKI_SITE],
+        client=client,
+    )
+
+    df = enum.run()
+
+    assert isinstance(df, pd.DataFrame)
+    assert not df.empty
+    assert set(df["enumeration_mode"]) == {"REACTION"}
+    assert set(df["reaction_id"]) == {"suzuki"}
+    assert df["building_block_id"].astype(str).str.len().gt(0).all()
+
+
+# -- payload construction (no network beyond client init) ---------------------
+
+
+def test_enumerator_scaffold_payload(client: DeepOriginClient) -> None:
+    """SCAFFOLD payload carries replace_ix, MMP params, and top-level sync."""
+    parent = Ligand.from_smiles(_PARENT_SMILES)
+    enum = Enumerator(
+        ligand=parent,
+        job_type="SCAFFOLD",
+        replace_ix=3,
+        radius=2,
+        max_fragment_size=5,
+        client=client,
+    )
+    payload = enum._make_payload(sync=True)
+
+    inputs = payload["inputs"]
+    assert payload["sync"] is True
+    assert "sync" not in inputs
+    assert inputs["ligand"] == {"smiles": _PARENT_SMILES}
+    assert inputs["job_type"] == "SCAFFOLD"
+    assert inputs["replace_ix"] == [3]
+    assert inputs["radius"] == 2
+    assert inputs["max_fragment_size"] == 5
+    assert "reaction_sites" not in inputs
+
+
+def test_enumerator_reaction_payload(client: DeepOriginClient) -> None:
+    """REACTION payload carries cleaned reaction_sites and no MMP params."""
+    parent = Ligand.from_smiles(_PARENT_SMILES)
+    enum = Enumerator(
+        ligand=parent,
+        job_type="REACTION",
+        reaction_sites=[{**_SUZUKI_SITE, "extra": "ignored"}],
+        client=client,
+    )
+    inputs = enum._make_payload(sync=True)["inputs"]
+
+    assert inputs["reaction_sites"] == [_SUZUKI_SITE]
+    assert "replace_ix" not in inputs
+    assert "radius" not in inputs
+
+
+def test_enumerator_available_reactions_payload(client: DeepOriginClient) -> None:
+    """AVAILABLE_REACTIONS payload carries only the ligand and job_type."""
+    parent = Ligand.from_smiles(_PARENT_SMILES)
+    enum = Enumerator(ligand=parent, job_type="AVAILABLE_REACTIONS", client=client)
+    inputs = enum._make_payload(sync=True)["inputs"]
+
+    assert set(inputs) == {"ligand", "job_type"}
+
+
+def test_enumerator_payload_includes_ligand_id(client: DeepOriginClient) -> None:
+    """A ligand id is echoed into the payload ligand block."""
+    parent = Ligand.from_smiles(_PARENT_SMILES)
+    parent.id = "lig-123"
+    enum = Enumerator(ligand=parent, job_type="SCAFFOLD", replace_ix=0, client=client)
+    inputs = enum._make_payload(sync=True)["inputs"]
+
+    assert inputs["ligand"] == {"smiles": _PARENT_SMILES, "id": "lig-123"}
+
+
+# -- validation ----------------------------------------------------------------
+
+
+def test_enumerator_rejects_unknown_job_type(client: DeepOriginClient) -> None:
+    """An unknown job_type raises ValueError."""
+    parent = Ligand.from_smiles(_PARENT_SMILES)
+    with pytest.raises(ValueError, match="Unknown job_type"):
+        Enumerator(ligand=parent, job_type="MUTATE", replace_ix=0, client=client)
+
+
+def test_enumerator_scaffold_requires_single_replace_ix(
+    client: DeepOriginClient,
+) -> None:
+    """SCAFFOLD requires exactly one replace_ix."""
+    parent = Ligand.from_smiles(_PARENT_SMILES)
+    with pytest.raises(ValueError, match="exactly one replace_ix"):
+        Enumerator(ligand=parent, job_type="SCAFFOLD", replace_ix=[0, 1], client=client)
+
+
+def test_enumerator_scaffold_requires_replace_ix(client: DeepOriginClient) -> None:
+    """SCAFFOLD without replace_ix raises."""
+    parent = Ligand.from_smiles(_PARENT_SMILES)
+    with pytest.raises(ValueError, match="requires replace_ix"):
+        Enumerator(ligand=parent, job_type="SCAFFOLD", client=client)
+
+
+def test_enumerator_analogue_requires_replace_ix(client: DeepOriginClient) -> None:
+    """ANALOGUE without replace_ix raises."""
+    parent = Ligand.from_smiles(_PARENT_SMILES)
+    with pytest.raises(ValueError, match="requires replace_ix"):
+        Enumerator(ligand=parent, job_type="ANALOGUE", client=client)
+
+
+def test_enumerator_reaction_requires_sites(client: DeepOriginClient) -> None:
+    """REACTION without reaction_sites raises."""
+    parent = Ligand.from_smiles(_PARENT_SMILES)
+    with pytest.raises(ValueError, match="non-empty reaction_sites"):
+        Enumerator(ligand=parent, job_type="REACTION", client=client)
+
+
+def test_enumerator_reaction_rejects_replace_ix(client: DeepOriginClient) -> None:
+    """REACTION with replace_ix raises."""
+    parent = Ligand.from_smiles(_PARENT_SMILES)
+    with pytest.raises(ValueError, match="replace_ix is not allowed"):
+        Enumerator(
+            ligand=parent,
+            job_type="REACTION",
+            reaction_sites=[_SUZUKI_SITE],
+            replace_ix=0,
+            client=client,
+        )
+
+
+def test_enumerator_available_reactions_rejects_extra_inputs(
+    client: DeepOriginClient,
+) -> None:
+    """AVAILABLE_REACTIONS with replace_ix raises."""
+    parent = Ligand.from_smiles(_PARENT_SMILES)
+    with pytest.raises(ValueError, match="AVAILABLE_REACTIONS takes only a ligand"):
+        Enumerator(
+            ligand=parent,
+            job_type="AVAILABLE_REACTIONS",
+            replace_ix=0,
+            client=client,
+        )
+
+
+def test_enumerator_rejects_radius_out_of_range(client: DeepOriginClient) -> None:
+    """radius above the allowed maximum raises."""
+    parent = Ligand.from_smiles(_PARENT_SMILES)
+    with pytest.raises(ValueError, match="radius must be between"):
+        Enumerator(
+            ligand=parent,
+            job_type="SCAFFOLD",
+            replace_ix=0,
+            radius=6,
+            client=client,
+        )
+
+
+def test_enumerator_rejects_max_fragment_size_out_of_range(
+    client: DeepOriginClient,
+) -> None:
+    """max_fragment_size above the allowed maximum raises."""
+    parent = Ligand.from_smiles(_PARENT_SMILES)
+    with pytest.raises(ValueError, match="max_fragment_size must be between"):
+        Enumerator(
+            ligand=parent,
+            job_type="SCAFFOLD",
+            replace_ix=0,
+            max_fragment_size=16,
+            client=client,
+        )
+
+
+# -- rehydration ---------------------------------------------------------------
+
+
+def test_enumerator_from_dto_rehydrates_inputs(client: DeepOriginClient) -> None:
+    """from_dto restores ligand SMILES and mode-specific inputs."""
+    _assert_tool_available(client)
+    parent = Ligand.from_smiles(_PARENT_SMILES)
+    enum = Enumerator(ligand=parent, job_type="SCAFFOLD", replace_ix=3, client=client)
+    enum.run()
+
+    restored = Enumerator.from_dto(enum.dto, client=client)
+
+    assert restored.job_type == "SCAFFOLD"
+    assert restored.ligand.smiles == _PARENT_SMILES
+    assert restored.replace_ix == [3]

--- a/tests/test_enumerator_local.py
+++ b/tests/test_enumerator_local.py
@@ -271,6 +271,22 @@ def test_enumerator_rejects_max_fragment_size_out_of_range(
         )
 
 
+def test_enumerator_ignores_mmp_bounds_for_non_mmp_modes(
+    client: DeepOriginClient,
+) -> None:
+    """radius / max_fragment_size bounds are not enforced outside MMP modes."""
+    parent = Ligand.from_smiles(_PARENT_SMILES)
+    enum = Enumerator(
+        ligand=parent,
+        job_type="AVAILABLE_REACTIONS",
+        radius=99,
+        max_fragment_size=99,
+        client=client,
+    )
+
+    assert enum.job_type == "AVAILABLE_REACTIONS"
+
+
 # -- rehydration ---------------------------------------------------------------
 
 
@@ -286,3 +302,22 @@ def test_enumerator_from_dto_rehydrates_inputs(client: DeepOriginClient) -> None
     assert restored.job_type == "SCAFFOLD"
     assert restored.ligand.smiles == _PARENT_SMILES
     assert restored.replace_ix == [3]
+
+
+def test_enumerator_from_dto_rejects_missing_job_type(
+    client: DeepOriginClient,
+) -> None:
+    """from_dto fails fast when the stored inputs carry no usable job_type."""
+    _assert_tool_available(client)
+    parent = Ligand.from_smiles(_PARENT_SMILES)
+    enum = Enumerator(ligand=parent, job_type="SCAFFOLD", replace_ix=3, client=client)
+    enum.run()
+
+    dto = dict(enum.dto)
+    inputs = dict(dto.get("userInputs") or dto.get("inputs") or {})
+    inputs.pop("job_type", None)
+    dto["userInputs"] = inputs
+    dto["inputs"] = inputs
+
+    with pytest.raises(ValueError, match="unknown job_type"):
+        Enumerator.from_dto(dto, client=client)

--- a/zensical.toml
+++ b/zensical.toml
@@ -33,6 +33,7 @@ nav = [
       {"Docking" = "dd/tools/docking.md"},
       {"SystemPrep" = "dd/tools/systemprep.md"},
       {"Molprops" = "dd/tools/molprops.md"},
+      {"Enumerator" = "dd/tools/enumerator.md"},
       {"ABFE" = "dd/tools/abfe.md"},
     ]},
     {"Notebooks" = [
@@ -58,6 +59,7 @@ nav = [
     {"docking" = "dd/ref/docking.md"},
     {"constrained_docking" = "dd/ref/constrained_docking.md"},
     {"pocket_finder" = "dd/ref/pocket_finder.md"},
+    {"enumerator" = "dd/ref/enumerator.md"},
     {"konnektor" = "dd/ref/konnektor.md"},
     {"abfe" = "dd/ref/abfe.md"},
     {"rbfe" = "dd/ref/rbfe.md"},


### PR DESCRIPTION
## Summary

Adds first-class support for the served `deeporigin.enumerator` tool to the drug
discovery SDK: a new `Enumerator` execution type with mode-specific validation
(`SCAFFOLD`, `ANALOGUE`, `AVAILABLE_REACTIONS`, `REACTION`), synchronous execution,
result parsing into a `pandas.DataFrame`, mock-server routes, tests, docs, and a
demo notebook.

<!-- merge-ready:auto -->
### Merge-ready status

_Auto-updated — cycle 1, last updated: 2026-07-16T18:48:00Z_

| Check | Status |
|-------|--------|
| Branch vs `main` | ✅ synced (`a488632`, 0 behind) |
| Head | `b3bf168` |
| CI | ❌ blocked by unrelated live-platform flakiness (escalated to maintainer) |
| Copilot | ✅ 2 nits fixed + threads resolved; re-review requested on `b3bf168` |
| Review threads | 0 human/Bugbot, 0 open Copilot |

**Recent activity**
- Triaged 2 Copilot nits: scoped `radius` / `max_fragment_size` bounds to MMP modes
  and made `from_dto` fail fast on missing/unknown `job_type`; added tests; both
  threads replied to and resolved.
- CI blocker is environmental (dev-platform read-after-create 404 on unrelated ligand
  tests) — left red for a maintainer to re-run/merge once the platform is healthy.

**CI blocker (environmental, not this PR):** `level-1-tests` fails only on two
live-instance ligand tests in `tests/test_entities.py`
(`test_ligand_register_passes_tags_lv1`, `test_ligand_sync_applies_tags_to_existing_row_lv1`),
both raising `Ligand not readable after create` — HTTP 404 from the dev platform
within the 15s read-after-create window. Neither test is touched by this PR (which only
adds the enumerator), and `level-1-tests` passes on `main`. This is dev-platform
read-after-create flakiness and cannot be fixed from this branch; needs a re-run once
the platform is healthy.
<!-- /merge-ready:auto -->

