### PR TITLE
feat(constrained-docking): allow SMILES-only test ligands (DDOS-6815)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -162,6 +162,9 @@ _Avoid_: blocking CLI/toolbox work on UUI pose-input UX
 **Test ligand**:
 Ligand to constrain-dock relative to the reference; CLI `ligand` / `ligands`;
 platform input `ligands[]`. Constraints are derived server-side via MCS.
+Test ligands may be SMILES-only (no structure file); the server embeds an
+ephemeral 3D structure for MCS. Reference ligand and reference pose still
+require 3D structure files on the platform.
 _Avoid_: Reference ligand; ligand (when you mean only the test set)
 
 **Free-dock fallback**:

--- a/docs/dd/tools/docking.md
+++ b/docs/dd/tools/docking.md
@@ -188,8 +188,32 @@ cd = ConstrainedDocking(
 poses = cd.run()
 ```
 
-Each test ligand must have a structure file on the platform (load from SDF/MOL2
-and call ``ligand.sync()``). The reference pose must have 3D coordinates.
+Each test ligand must have SMILES or a structure file on the platform (load from
+SDF/MOL2 and call ``ligand.sync()``, or use ``Ligand.from_smiles`` and call
+``ligand.sync()``). The reference pose must have 3D coordinates.
+
+### SMILES-only test ligands
+
+When a test ligand has no structure file, provide SMILES and sync the entity:
+
+```{.python notest}
+from deeporigin.drug_discovery import ConstrainedDocking, Ligand
+
+test_ligand = Ligand.from_smiles("CC(C)O")
+test_ligand.sync()
+
+cd = ConstrainedDocking(
+    protein=protein,
+    pocket=pocket,
+    reference_ligand=reference_ligand,
+    reference_pose=reference_pose,
+    ligand=test_ligand,
+)
+poses = cd.run()
+```
+
+The platform embeds the SMILES to an ephemeral 3D structure for MCS alignment.
+Reference ligand and reference pose still require structure files on the platform.
 
 To view new poses together with the reference pose:
 

--- a/src/drug_discovery/class-design.md
+++ b/src/drug_discovery/class-design.md
@@ -42,7 +42,7 @@ module owns tool-specific payload and validation.
 |--------|----------------|
 | `docking_common.py` | Pocket box geometry, execution metadata, pose loading from platform/`jobOutputs` |
 | `docking.py` | `Docking` — bulk/async docking; ligand rows are `id` + `smiles` only |
-| `constrained_docking.py` | `ConstrainedDocking` — sync + async; server-derived MCS constraints from required `reference_ligand` + `reference_pose`; ligand rows include `file_path` |
+| `constrained_docking.py` | `ConstrainedDocking` — sync + async; server-derived MCS constraints from required `reference_ligand` + `reference_pose`; test ligand rows use `file_path` or `{id, smiles}` when SMILES-only |
 
 Do not import `ConstrainedDocking` from `docking.py` or vice versa. Both import shared
 helpers from `docking_common.py`. Tool-specific helpers (e.g. `_ligand_tool_input_row`,

--- a/src/drug_discovery/constrained_docking.py
+++ b/src/drug_discovery/constrained_docking.py
@@ -30,19 +30,26 @@ from deeporigin.platform.constants import TOOL_KEYS_AND_VERSIONS, is_success_sta
 
 def _constrained_ligand_tool_input_row(lig: Ligand) -> dict[str, Any]:
     """Build one test-ligand entry for constrained docking tool inputs."""
-    if lig.remote_path is None:
-        raise ValueError(
-            "Ligand must be synced to the platform with a structure file "
-            "(remote_path) for constrained docking. Use Ligand.from_file or "
-            "from_sdf and call ligand.sync() before running."
-        )
-    row: dict[str, Any] = {
-        "id": lig.id,
-        "file_path": lig.remote_path,
-    }
+    if lig.remote_path is not None:
+        row: dict[str, Any] = {
+            "id": lig.id,
+            "file_path": lig.remote_path,
+        }
+        if lig.smiles is not None:
+            row["smiles"] = lig.smiles
+        return row
     if lig.smiles is not None:
-        row["smiles"] = lig.smiles
-    return row
+        if lig.id is None:
+            raise ValueError(
+                "Test ligand must be synced to the platform before running "
+                "constrained docking with SMILES only. Call ligand.sync()."
+            )
+        return {"id": lig.id, "smiles": lig.smiles}
+    raise ValueError(
+        "Test ligand must have a structure file on the platform or SMILES for "
+        "constrained docking. Use Ligand.from_file or from_sdf and call "
+        "ligand.sync(), or Ligand.from_smiles and call ligand.sync()."
+    )
 
 
 def _reference_ligand_tool_input_row(lig: Ligand) -> dict[str, Any]:
@@ -299,7 +306,8 @@ class ConstrainedDocking(
     reference ligand pose via MCS alignment. Callers supply
     ``reference_ligand`` (scaffold identity) and ``reference_pose`` (3D
     coordinates); the platform derives per-atom constraints for each test
-    ligand.
+    ligand. Test ligands may be SMILES-only (no structure file) when
+    ``lig.smiles`` is set; the server embeds an ephemeral 3D structure for MCS.
 
     :meth:`run` sets ``inputs.sync=true`` for exactly **one** test ligand
     (blocking). :meth:`start` sets ``inputs.sync=false`` for **two or more**
@@ -512,10 +520,15 @@ class ConstrainedDocking(
                 "reference_pose must have a structure file on the platform."
             )
         for lig in self.ligands:
-            if lig.remote_path is None:
+            if lig.remote_path is None and lig.smiles is None:
                 raise ValueError(
                     "Each test ligand must have a structure file on the platform "
-                    "for constrained docking."
+                    "or SMILES for constrained docking."
+                )
+            if lig.remote_path is None and lig.id is None:
+                raise ValueError(
+                    "Each SMILES-only test ligand must be synced to the platform "
+                    "before running constrained docking. Call ligands.sync()."
                 )
 
     def _build_tool_inputs(

--- a/tests/test_constrained_docking.py
+++ b/tests/test_constrained_docking.py
@@ -7,7 +7,10 @@ from unittest.mock import patch
 import pytest
 
 from deeporigin.drug_discovery import BRD_DATA_DIR, ConstrainedDocking, Docking, Ligand
-from deeporigin.drug_discovery.constrained_docking import _reference_pose_tool_input_row
+from deeporigin.drug_discovery.constrained_docking import (
+    _constrained_ligand_tool_input_row,
+    _reference_pose_tool_input_row,
+)
 from deeporigin.drug_discovery.docking_common import load_docking_poses_from_execution
 from deeporigin.drug_discovery.structures.ligand import (
     LigandSet,
@@ -16,6 +19,7 @@ from deeporigin.drug_discovery.structures.ligand import (
 from deeporigin.exceptions import DeepOriginException
 from deeporigin.platform.constants import TOOL_KEYS_AND_VERSIONS
 from tests.conftest import check_tool_exists
+from tests.test_entities import _unique_test_smiles
 
 
 def _make_reference_pair() -> tuple[Ligand, Ligand]:
@@ -23,6 +27,173 @@ def _make_reference_pair() -> tuple[Ligand, Ligand]:
     reference_ligand = Ligand.from_sdf(BRD_DATA_DIR / "brd-2.sdf")
     reference_pose = Ligand.from_sdf(BRD_DATA_DIR / "brd-2.sdf")
     return reference_ligand, reference_pose
+
+
+def test_constrained_ligand_tool_input_row_smiles_only() -> None:
+    """SMILES-only test ligands emit id and smiles without file_path."""
+    lig = Ligand.from_smiles("CCO")
+    lig.id = "lig-smiles-only"
+
+    row = _constrained_ligand_tool_input_row(lig)
+
+    assert row == {"id": "lig-smiles-only", "smiles": "CCO"}
+    assert "file_path" not in row
+
+
+def test_constrained_ligand_tool_input_row_still_includes_file_path() -> None:
+    """Structure-file test ligands still emit file_path."""
+    lig = Ligand.from_sdf(BRD_DATA_DIR / "brd-3.sdf")
+    lig.id = "brd-3"
+    lig.remote_path = "testing/brd-3.sdf"
+
+    row = _constrained_ligand_tool_input_row(lig)
+
+    assert row["file_path"] == "testing/brd-3.sdf"
+    assert row["id"] == "brd-3"
+
+
+def test_constrained_ligand_tool_input_row_rejects_no_file_no_smiles() -> None:
+    """Test ligands without structure file or SMILES are rejected."""
+    lig = Ligand.from_smiles("CCO")
+    lig.smiles = None
+
+    with pytest.raises(ValueError, match="structure file on the platform or SMILES"):
+        _constrained_ligand_tool_input_row(lig)
+
+
+def test_constrained_ligand_tool_input_row_smiles_only_requires_id() -> None:
+    """SMILES-only rows require a synced platform entity id."""
+    lig = Ligand.from_smiles("CCO")
+
+    with pytest.raises(ValueError, match="synced to the platform"):
+        _constrained_ligand_tool_input_row(lig)
+
+
+def test_ensure_platform_inputs_accepts_smiles_only_test_ligand(
+    client,
+    registered_protein,
+    unregistered_pocket,
+) -> None:
+    """SMILES-only test ligands pass validation after sync when id is set."""
+    reference_ligand, reference_pose = _make_reference_pair()
+    reference_ligand.remote_path = "testing/brd-2.sdf"
+    reference_ligand.id = "brd-2"
+    reference_pose.remote_path = "testing/docked-pose.sdf"
+    reference_pose.id = "brd-2"
+    reference_pose.properties["pose_result_id"] = "pose-from-docking"
+
+    test_ligand = Ligand.from_smiles("CC(C)O")
+    test_ligand.id = "smiles-only-test"
+
+    cd = ConstrainedDocking(
+        protein=registered_protein,
+        pocket=unregistered_pocket,
+        reference_ligand=reference_ligand,
+        reference_pose=reference_pose,
+        ligand=test_ligand,
+        client=client,
+    )
+
+    with (
+        patch.object(cd.protein, "sync") as protein_sync,
+        patch.object(cd.reference_ligand, "sync") as ref_ligand_sync,
+        patch.object(cd.reference_pose, "sync") as ref_pose_sync,
+        patch.object(cd.ligands, "sync") as ligands_sync,
+    ):
+        cd._ensure_platform_inputs()
+
+    protein_sync.assert_called_once()
+    ref_ligand_sync.assert_called_once()
+    ref_pose_sync.assert_not_called()
+    ligands_sync.assert_called_once()
+
+
+def test_build_tool_inputs_smiles_only_test_ligand(
+    client,
+    registered_protein,
+    unregistered_pocket,
+) -> None:
+    """Payload omits file_path on SMILES-only test ligands."""
+    reference_ligand, reference_pose = _make_reference_pair()
+    reference_ligand.remote_path = "testing/brd-2.sdf"
+    reference_ligand.id = "brd-2"
+    reference_pose.remote_path = "testing/docked-pose.sdf"
+    reference_pose.id = "brd-2"
+    reference_pose.properties["pose_result_id"] = "pose-from-docking"
+
+    test_ligand = Ligand.from_smiles("CC(C)O")
+    test_ligand.id = "smiles-only-test"
+
+    cd = ConstrainedDocking(
+        protein=registered_protein,
+        pocket=unregistered_pocket,
+        reference_ligand=reference_ligand,
+        reference_pose=reference_pose,
+        ligand=test_ligand,
+        client=client,
+    )
+
+    with (
+        patch.object(cd.protein, "sync"),
+        patch.object(cd.reference_ligand, "sync"),
+        patch.object(cd.reference_pose, "sync"),
+        patch.object(cd.ligands, "sync"),
+    ):
+        cd._ensure_platform_inputs()
+
+    params, _metadata = cd._build_tool_inputs()
+
+    assert len(params["ligands"]) == 1
+    assert params["ligands"][0] == {
+        "id": "smiles-only-test",
+        "smiles": "CC(C)O",
+    }
+    assert "file_path" not in params["ligands"][0]
+
+
+@pytest.mark.expects_results
+def test_constrained_docking_run_quote_true_smiles_only_test_ligand(
+    client,
+    registered_protein,
+    unregistered_pocket,
+) -> None:
+    """run(quote=True) accepts SMILES-only test ligands against the platform."""
+    assert check_tool_exists(
+        client,
+        TOOL_KEYS_AND_VERSIONS["constrained_docking"]["tool_key"],
+        TOOL_KEYS_AND_VERSIONS["constrained_docking"]["tool_version"],
+    ), "Constrained docking tool not registered on platform."
+
+    reference_ligand, reference_pose = _make_reference_pair()
+    reference_ligand.sync(
+        client=client,
+        remote_path="testing/constrained-docking/brd-2.sdf",
+    )
+    reference_pose.sync(
+        client=client,
+        remote_path="testing/constrained-docking/brd-2-pose.sdf",
+    )
+
+    test_ligand = Ligand.from_smiles(_unique_test_smiles(suffix="O"))
+    test_ligand.sync(client=client)
+    assert test_ligand.remote_path is None
+
+    cd = ConstrainedDocking(
+        protein=registered_protein,
+        pocket=unregistered_pocket,
+        reference_ligand=reference_ligand,
+        reference_pose=reference_pose,
+        ligand=test_ligand,
+        client=client,
+    )
+    params, _metadata = cd._build_tool_inputs()
+    assert "file_path" not in params["ligands"][0]
+
+    result = cd.run(quote=True)
+
+    assert result is None
+    assert cd.estimate is not None
+    assert cd.status == "Quoted"
 
 
 def test_reference_pose_tool_input_row_uses_pose_result_id() -> None:


### PR DESCRIPTION
## Summary

Relax `ConstrainedDocking` client validation so test ligands can be submitted as `{id, smiles}` without a structure file, matching the platform-toolbox server support shipped in [platform-toolbox#773](https://github.com/deeporiginbio/platform-toolbox/pull/773) / [DDOS-6832](https://deeporigin.atlassian.net/browse/DDOS-6832). Reference ligand and reference pose still require structure files on the platform.

**Jira:** [DDOS-6815](https://deeporigin.atlassian.net/browse/DDOS-6815)

<!-- merge-ready:auto -->
### Merge-ready status

_Auto-updated — cycle 1 complete, last updated: 2026-07-29T14:05:00Z_

| Check | Status |
|-------|--------|
| Branch vs `main` | ✅ synced (MERGEABLE) |
| Head | `f5791e39` |
| CI | ✅ green (12/12) |
| Copilot | ✅ reviewed latest push, 0 open threads |
| Review threads | 0 human/Bugbot, 0 Copilot |

**Recent activity**
- Copilot re-reviewed — no new nits.
- Local + dev SMILES-only tests passed.
<!-- /merge-ready:auto -->

## Test plan

- [x] `uv run pytest tests/test_constrained_docking.py --env local -x` (28 passed)
- [x] `uv run pytest tests/test_constrained_docking.py --env dev -x -k "smiles_only or quote"` (6 passed)
- [ ] CI green on PR

[DDOS-6832]: https://deeporigin.atlassian.net/browse/DDOS-6832?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DDOS-6815]: https://deeporigin.atlassian.net/browse/DDOS-6815?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
