### PR TITLE
feat(admet): expose method parameter for togo/maplight inference

### DIFF
--- a/docs/dd/how-to/ligands.md
+++ b/docs/dd/how-to/ligands.md
@@ -531,7 +531,10 @@ Unlike :class:`~deeporigin.drug_discovery.molprops.Molprops`, ``Admet.run()`` re
 
 Property names match the platform tool keys (for example ``hERG_classification``,
 ``PPB_regression``, ``CYP450_3A4_Inhibitor_classification``). Omit ``properties``
-to request all wired endpoints, or pass a list to limit the run:
+to request all wired endpoints, or pass a list to limit the run.
+
+Use ``method="togo"`` (default) for three-dimensional embedding models, or
+``method="maplight"`` for fingerprint-based models:
 
 ```{.python notest}
 from deeporigin.drug_discovery import Admet, Ligand
@@ -540,6 +543,16 @@ ligand = Ligand.from_smiles("CCO")
 df = Admet(
     ligands=[ligand],
     properties=["hERG_classification", "AMES_classification"],
+).run()
+```
+
+For MapLight explicitly:
+
+```{.python notest}
+df = Admet(
+    ligands=[ligand],
+    properties=["hERG_classification", "AMES_classification"],
+    method="maplight",
 ).run()
 ```
 

--- a/src/drug_discovery/admet.py
+++ b/src/drug_discovery/admet.py
@@ -55,15 +55,20 @@ def _validate_admet_properties(properties: list[str] | None) -> list[str] | None
 
 
 def _execution_predictions(dto: dict[str, Any]) -> list[dict[str, Any]]:
-    """Return per-ligand prediction rows from an admet-properties execution DTO."""
+    """Return per-ligand prediction rows from an admet-properties execution DTO.
+
+    The served tool schema wraps rows under ``admet_properties``. Older mock
+    responses used ``predictions``; both keys are accepted.
+    """
 
     job_outputs = dto.get("jobOutputs")
     if not isinstance(job_outputs, dict):
         return []
-    predictions = job_outputs.get("predictions")
-    if not isinstance(predictions, list):
-        return []
-    return [row for row in predictions if isinstance(row, dict)]
+    for key in ("admet_properties", "predictions"):
+        rows = job_outputs.get(key)
+        if isinstance(rows, list):
+            return [row for row in rows if isinstance(row, dict)]
+    return []
 
 
 class Admet(Execution, SyncExecutableMixin):
@@ -248,7 +253,8 @@ class Admet(Execution, SyncExecutableMixin):
             raise DeepOriginException(
                 title="ADMET predictions missing",
                 message=(
-                    f"Admet execution {self.id!r} returned no predictions in jobOutputs."
+                    f"Admet execution {self.id!r} returned no admet_properties "
+                    f"rows in jobOutputs."
                 ),
             )
 

--- a/src/drug_discovery/admet.py
+++ b/src/drug_discovery/admet.py
@@ -131,7 +131,9 @@ class Admet(Execution, SyncExecutableMixin):
             ligand_id = lig.id if lig.id is not None else str(idx)
             payload["id"] = str(ligand_id)
             ligand_payloads.append(payload)
-        inputs: dict[str, Any] = {"ligands": ligand_payloads, "method": self._method}
+        inputs: dict[str, Any] = {"ligands": ligand_payloads}
+        if self._method != "togo":
+            inputs["method"] = self._method
         if self._properties is not None:
             inputs["properties"] = self._properties
         return inputs

--- a/src/drug_discovery/admet.py
+++ b/src/drug_discovery/admet.py
@@ -19,7 +19,7 @@ Usage::
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Literal
 
 from beartype import beartype
 import pandas as pd
@@ -80,6 +80,7 @@ class Admet(Execution, SyncExecutableMixin):
     Attributes:
         ligands: Ligands whose SMILES are sent to the tool.
         properties: Optional admet-now property keys to request, or ``None`` for all.
+        method: Inference path — ``togo`` (default) or ``maplight``.
     """
 
     tool_key: str = TOOL_KEYS_AND_VERSIONS["admet"]["tool_key"]
@@ -91,6 +92,7 @@ class Admet(Execution, SyncExecutableMixin):
         *,
         ligands: list[Ligand] | LigandSet,
         properties: list[str] | None = None,
+        method: Literal["maplight", "togo"] = "togo",
         client: DeepOriginClient | None = None,
     ) -> None:
         """Configure an ADMET prediction run for one or more ligands."""
@@ -102,11 +104,17 @@ class Admet(Execution, SyncExecutableMixin):
         if not self._ligands:
             raise ValueError("Admet requires at least one ligand.")
         self._properties = _validate_admet_properties(properties)
+        self._method = method
 
     @property
     def ligands(self) -> list[Ligand]:
         """Ligands targeted by this run (read-only)."""
         return self._ligands
+
+    @property
+    def method(self) -> str:
+        """Selected admet-now inference method."""
+        return self._method
 
     @property
     def properties(self) -> tuple[str, ...] | None:
@@ -123,7 +131,7 @@ class Admet(Execution, SyncExecutableMixin):
             ligand_id = lig.id if lig.id is not None else str(idx)
             payload["id"] = str(ligand_id)
             ligand_payloads.append(payload)
-        inputs: dict[str, Any] = {"ligands": ligand_payloads}
+        inputs: dict[str, Any] = {"ligands": ligand_payloads, "method": self._method}
         if self._properties is not None:
             inputs["properties"] = self._properties
         return inputs

--- a/tests/mock_server/routers/tools.py
+++ b/tests/mock_server/routers/tools.py
@@ -1087,7 +1087,7 @@ def create_tools_router(
                 )
             )
 
-        execution["jobOutputs"] = {"predictions": rows}
+        execution["jobOutputs"] = {"admet_properties": rows}
         execution["quotationResult"] = {
             "anyFailed": False,
             "failedQuotations": [],

--- a/tests/test_admet_local.py
+++ b/tests/test_admet_local.py
@@ -59,3 +59,38 @@ def test_admet_run_quote_true(client: DeepOriginClient) -> None:
     assert ligand.id is None
     assert job.estimate is not None
     assert job.status == "Quoted"
+
+
+def test_admet_make_inputs_defaults_method_to_togo(client: DeepOriginClient) -> None:
+    """Omitting ``method`` forwards the Togo default to tool inputs."""
+    cfg = TOOL_KEYS_AND_VERSIONS["admet"]
+    assert check_tool_exists(client, cfg["tool_key"], cfg["tool_version"])
+
+    ligand = Ligand.from_smiles("CCO")
+    job = Admet(
+        ligands=[ligand],
+        properties=_ADMET_PROPERTIES,
+        client=client,
+    )
+    inputs = job._make_inputs()
+
+    assert inputs["method"] == "togo"
+    assert inputs["properties"] == _ADMET_PROPERTIES
+
+
+def test_admet_make_inputs_includes_method(client: DeepOriginClient) -> None:
+    """``method`` is forwarded to the tool inputs payload."""
+    cfg = TOOL_KEYS_AND_VERSIONS["admet"]
+    assert check_tool_exists(client, cfg["tool_key"], cfg["tool_version"])
+
+    ligand = Ligand.from_smiles("CCO")
+    job = Admet(
+        ligands=[ligand],
+        properties=_ADMET_PROPERTIES,
+        method="maplight",
+        client=client,
+    )
+    inputs = job._make_inputs()
+
+    assert inputs["method"] == "maplight"
+    assert inputs["properties"] == _ADMET_PROPERTIES

--- a/tests/test_admet_local.py
+++ b/tests/test_admet_local.py
@@ -62,7 +62,7 @@ def test_admet_run_quote_true(client: DeepOriginClient) -> None:
 
 
 def test_admet_make_inputs_defaults_method_to_togo(client: DeepOriginClient) -> None:
-    """Omitting ``method`` forwards the Togo default to tool inputs."""
+    """Default ``method`` is Togo and is omitted from inputs (tool default)."""
     cfg = TOOL_KEYS_AND_VERSIONS["admet"]
     assert check_tool_exists(client, cfg["tool_key"], cfg["tool_version"])
 
@@ -74,7 +74,8 @@ def test_admet_make_inputs_defaults_method_to_togo(client: DeepOriginClient) -> 
     )
     inputs = job._make_inputs()
 
-    assert inputs["method"] == "togo"
+    assert job.method == "togo"
+    assert "method" not in inputs
     assert inputs["properties"] == _ADMET_PROPERTIES
 
 

--- a/tests/test_admet_unit.py
+++ b/tests/test_admet_unit.py
@@ -1,0 +1,30 @@
+"""Unit tests for Admet execution DTO parsing helpers."""
+
+from __future__ import annotations
+
+from deeporigin.drug_discovery.admet import _execution_predictions
+
+
+def test_execution_predictions_reads_admet_properties() -> None:
+    """Platform jobOutputs use the admet_properties key from the tool schema."""
+    row = {
+        "smiles": "CCO",
+        "ligand_id": "0",
+        "hERG_classification": 0.5,
+    }
+    dto = {"jobOutputs": {"admet_properties": [row]}}
+    assert _execution_predictions(dto) == [row]
+
+
+def test_execution_predictions_falls_back_to_predictions_key() -> None:
+    """Legacy mock responses wrapped rows under predictions."""
+    row = {"smiles": "CCN", "ligand_id": "1", "AMES_classification": 0.1}
+    dto = {"jobOutputs": {"predictions": [row]}}
+    assert _execution_predictions(dto) == [row]
+
+
+def test_execution_predictions_empty_when_job_outputs_missing() -> None:
+    """Missing or malformed jobOutputs yields no rows."""
+    assert _execution_predictions({}) == []
+    assert _execution_predictions({"jobOutputs": None}) == []
+    assert _execution_predictions({"jobOutputs": {"other": []}}) == []


### PR DESCRIPTION
## Summary

Expose the `method` input on `Admet` so SDK callers can choose between Togo (default) and MapLight inference paths, matching the `deeporigin.admet-properties` tool schema.

<!-- merge-ready:auto -->
### Merge-ready status

_Auto-updated — cycle 3, last updated: 2026-07-30T00:31:20Z_

| Check | Status |
|-------|--------|
| Branch vs `main` | ✅ synced at `772b84d` |
| Head | `4491c20` |
| CI | ❌ dev + staging lv1 (rerun failed); prod ✅ |
| Copilot | ⏳ blocked on CI |
| Review threads | 0 human/Bugbot, 0 Copilot |

**Recent activity**
- Dev/staging lv1 reruns failed again (same admet platform errors).
- Prod lv1 + all unit/functionality checks green.
- Blocked on dev/staging platform — not fixable in this PR.
<!-- /merge-ready:auto -->

## Test plan

- [x] `uv run pytest tests/test_admet_local.py --env local`
- [ ] CI green on PR
- [ ] Copilot review clean




