### PR TITLE
fix(files): normalize leading slashes in UFA API paths

### DIFF
--- a/docs/platform/ref/files.md
+++ b/docs/platform/ref/files.md
@@ -14,6 +14,10 @@ Example:
 keys = client.files.list(remote_path="entities/")
 ```
 
+Remote paths may be stored with a leading slash (for example `/seeded/proteins/BRD.pdb`
+from the data platform). The client strips leading slashes before calling the
+file-service API so signed URLs and direct downloads resolve correctly.
+
 ## Choosing a method
 
 Use this table to pick the right call. The client uses **two upload styles** (multipart via the platform API vs. signed URLs to object storage) and **two download styles** (signed URL streaming vs. direct GET through the API).

--- a/src/platform/files.py
+++ b/src/platform/files.py
@@ -22,6 +22,27 @@ _FILES_BASE = "/files"
 
 _MISSING_URL_FIELD = "Signed URL response missing 'url' field"
 
+
+def _normalize_remote_path(remote_path: str) -> str:
+    """Normalize a UFA remote path for platform API URL segments.
+
+    Data-platform rows and UUI often store paths with a leading slash
+    (e.g. ``/seeded/proteins/BRD.pdb``). The file-service expects keys without
+    one; embedding a leading slash in ``/signedUrl/{path}`` creates a double
+    slash that misses the signedUrl route and returns 404.
+
+    Args:
+        remote_path: Raw remote path from the caller.
+
+    Returns:
+        Path with leading slashes removed and repeated ``/`` collapsed.
+    """
+    normalized = remote_path.replace("\\", "/")
+    while "//" in normalized:
+        normalized = normalized.replace("//", "/")
+    return normalized.lstrip("/")
+
+
 # Signed-URL PUTs upload full file bodies; default httpx read timeout (5s) is too
 # short under concurrent upload_tree workers waiting on S3.
 _SIGNED_URL_UPLOAD_TIMEOUT = httpx.Timeout(
@@ -322,6 +343,7 @@ class Files:
         Raises:
             ValueError: If the API response is missing the 'url' field.
         """
+        remote_path = _normalize_remote_path(remote_path)
         params = {"upload": "true"} if upload else {}
 
         response = self._c.get_json(
@@ -486,6 +508,7 @@ class Files:
             RuntimeError: If any upload fails and ``skip_errors`` is False.
             ValueError: If ``local_path`` is not a file, directory, or list.
         """
+        remote_dir = _normalize_remote_path(remote_dir)
         if not remote_dir.endswith("/"):
             remote_dir += "/"
 
@@ -619,6 +642,7 @@ class Files:
         Returns:
             Either a list of remote keys or a list of metadata dicts.
         """
+        remote_path = _normalize_remote_path(remote_path)
         all_keys: list[str] = []
         all_objects: list[dict] = []
         continuation_token: str | None = None
@@ -665,7 +689,7 @@ class Files:
             Dictionary containing the upload response (e.g., eTag, s3 metadata).
         """
         local_path_str = str(local_path)
-        remote_path_str = str(remote_path)
+        remote_path_str = _normalize_remote_path(str(remote_path))
 
         # Read file content
         with open(local_path_str, "rb") as f:
@@ -766,6 +790,7 @@ class Files:
         Returns:
             The local path where the file was saved.
         """
+        remote_path = _normalize_remote_path(remote_path)
         dest: Path
         if direct:
             if local_path is not None:
@@ -866,6 +891,7 @@ class Files:
                 field.
             httpx.HTTPStatusError: If the server returns a non-2xx status.
         """
+        remote_path = _normalize_remote_path(remote_path)
         if direct:
             self._c.check_token()
             request = self._c._client.build_request(
@@ -984,6 +1010,7 @@ class Files:
                 200 status even if deletion fails, so this method checks the
                 response body for success.
         """
+        remote_path = _normalize_remote_path(remote_path)
         # Temporarily increase timeout if specified
         original_timeout = None
         if timeout is not None:
@@ -1062,6 +1089,7 @@ class Files:
         Returns:
             HTTP response headers (content-type, content-length, etag, etc.).
         """
+        remote_path = _normalize_remote_path(remote_path)
         response = self._c._head(f"/files/{self._c.org_key}/{remote_path}")
         return dict(response.headers)
 
@@ -1083,6 +1111,7 @@ class Files:
         Returns:
             The JSON response from the API.
         """
+        remote_path = _normalize_remote_path(remote_path)
         response = self._c._post(
             f"/files/{self._c.org_key}/{remote_path}",
             body={"url": source_url},
@@ -1108,6 +1137,7 @@ class Files:
         Returns:
             The local path where the ZIP file was saved.
         """
+        remote_path = _normalize_remote_path(remote_path)
         if local_path is not None:
             dest = Path(local_path)
         elif download_to_dir is not None:

--- a/src/platform/files.py
+++ b/src/platform/files.py
@@ -508,7 +508,6 @@ class Files:
             RuntimeError: If any upload fails and ``skip_errors`` is False.
             ValueError: If ``local_path`` is not a file, directory, or list.
         """
-        remote_dir = _normalize_remote_path(remote_dir)
         if not remote_dir.endswith("/"):
             remote_dir += "/"
 

--- a/tests/test_files_remote_path_normalization.py
+++ b/tests/test_files_remote_path_normalization.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import httpx
 import pytest
 
@@ -42,7 +44,9 @@ def test_signed_url_uses_normalized_path(client: DeepOriginClient) -> None:
 
 
 def test_download_direct_uses_normalized_path(
-    client: DeepOriginClient, monkeypatch: pytest.MonkeyPatch
+    client: DeepOriginClient,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
     """direct downloads must hit GET /files/{org}/{path} without a leading slash."""
     captured: list[str] = []
@@ -55,7 +59,7 @@ def test_download_direct_uses_normalized_path(
 
     local_path = client.files.download(
         remote_path="/seeded/proteins/BRD/BRD.pdb",
-        download_to_dir="/tmp",
+        download_to_dir=str(tmp_path),
         direct=True,
     )
 

--- a/tests/test_files_remote_path_normalization.py
+++ b/tests/test_files_remote_path_normalization.py
@@ -1,0 +1,81 @@
+"""Tests for UFA remote path normalization in the Files client."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from deeporigin.platform.client import DeepOriginClient
+from deeporigin.platform.files import _normalize_remote_path
+
+
+def test_normalize_remote_path_strips_leading_slash() -> None:
+    """Leading slashes are removed before building file-service URLs."""
+    assert _normalize_remote_path("/seeded/proteins/BRD/BRD.pdb") == (
+        "seeded/proteins/BRD/BRD.pdb"
+    )
+
+
+def test_normalize_remote_path_collapses_duplicate_slashes() -> None:
+    """Repeated slashes are collapsed to a single separator."""
+    assert _normalize_remote_path("//seeded//proteins/BRD.pdb") == (
+        "seeded/proteins/BRD.pdb"
+    )
+
+
+def test_signed_url_uses_normalized_path(client: DeepOriginClient) -> None:
+    """signed_url must not embed a leading slash in the signedUrl segment."""
+    captured: list[str] = []
+
+    def fake_get_json(path: str, **kwargs: object) -> dict[str, str]:
+        captured.append(path)
+        return {"url": "https://example.com/object"}
+
+    client.get_json = fake_get_json  # type: ignore[method-assign]
+
+    url = client.files.signed_url("/seeded/proteins/BRD/BRD.pdb")
+
+    assert url == "https://example.com/object"
+    assert captured == [
+        f"/files/{client.org_key}/signedUrl/seeded/proteins/BRD/BRD.pdb"
+    ]
+
+
+def test_download_direct_uses_normalized_path(
+    client: DeepOriginClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """direct downloads must hit GET /files/{org}/{path} without a leading slash."""
+    captured: list[str] = []
+
+    def fake_get(path: str, **kwargs: object) -> httpx.Response:
+        captured.append(path)
+        return httpx.Response(200, content=b"ATOM")
+
+    monkeypatch.setattr(client, "_get", fake_get)
+
+    local_path = client.files.download(
+        remote_path="/seeded/proteins/BRD/BRD.pdb",
+        download_to_dir="/tmp",
+        direct=True,
+    )
+
+    assert captured == [f"/files/{client.org_key}/seeded/proteins/BRD/BRD.pdb"]
+    assert local_path.endswith("BRD.pdb")
+
+
+def test_stat_uses_normalized_path(
+    client: DeepOriginClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """stat must HEAD the normalized remote path."""
+    captured: list[str] = []
+
+    def fake_head(path: str, **kwargs: object) -> httpx.Response:
+        captured.append(path)
+        return httpx.Response(200, headers={"content-length": "1"})
+
+    monkeypatch.setattr(client, "_head", fake_head)
+
+    headers = client.files.stat("/seeded/proteins/BRD/BRD.pdb")
+
+    assert captured == [f"/files/{client.org_key}/seeded/proteins/BRD/BRD.pdb"]
+    assert headers["content-length"] == "1"


### PR DESCRIPTION
## Summary

Strip leading slashes from UFA remote paths before building file-service API URLs. Data-platform rows often store paths like `/seeded/proteins/BRD/BRD.pdb`; passing them verbatim into `/signedUrl/{path}` creates a double slash, routes to the wrong handler, and returns 404. This caused RBFE estimation failures when the fep-docking-parser estimator downloaded protein PDBs via ToolsSDK.

- Add `_normalize_remote_path()` and apply it across signed URL, direct GET/HEAD, upload, list, delete, and zip calls
- Unit tests cover normalization and signedUrl/direct/stat URL construction
- Document the behavior in the Files API reference

## Test plan

- [x] `uv run pytest tests/test_files_remote_path_normalization.py --env local`
- [ ] CI green on PR


Made with [Cursor](https://cursor.com)