### PR TITLE
fix(config): make deeporigin-sdk imports side-effect free (DDOS-6998)

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -12,6 +12,7 @@ Behavior:
 
 import json
 import os
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
 if TYPE_CHECKING:
@@ -19,9 +20,8 @@ if TYPE_CHECKING:
 
 from deeporigin.utils.constants import ENV_VARIABLES
 from deeporigin.utils.display import _supports_unicode_output
-from deeporigin.utils.env import _ensure_do_folder
 
-CONFIG_JSON_LOCATION = _ensure_do_folder() / "config.json"
+CONFIG_JSON_LOCATION = Path.home() / ".deeporigin" / "config.json"
 
 __all__ = [
     "get_org",

--- a/src/config.py
+++ b/src/config.py
@@ -36,9 +36,9 @@ __all__ = [
 def _ensure_config_file_exists() -> None:
     """Ensure the configuration file exists; create with defaults if missing."""
 
-    if not os.path.isfile(CONFIG_JSON_LOCATION):
+    if not CONFIG_JSON_LOCATION.is_file():
         default_data: dict = {"env": "prod", "org_key": ""}
-        os.makedirs(os.path.dirname(CONFIG_JSON_LOCATION), exist_ok=True)
+        CONFIG_JSON_LOCATION.parent.mkdir(parents=True, exist_ok=True)
         with open(CONFIG_JSON_LOCATION, "w") as file:
             json.dump(default_data, file, indent=2)
 

--- a/tests/test_import_side_effects.py
+++ b/tests/test_import_side_effects.py
@@ -2,19 +2,21 @@
 
 from __future__ import annotations
 
-from pathlib import Path
+import pathlib
 import sys
 
 import pytest
 
 
-def _blocked_home(tmp_path: Path) -> Path:
+def _blocked_home(tmp_path: pathlib.Path) -> pathlib.Path:
     """Return a HOME path whose parent directory does not exist."""
     return tmp_path / "missing" / "home"
 
 
 @pytest.fixture
-def blocked_home(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+def blocked_home(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib.Path
+) -> pathlib.Path:
     """Point HOME at a path whose parent cannot be created implicitly."""
     home = _blocked_home(tmp_path)
     monkeypatch.setenv("HOME", str(home))
@@ -29,7 +31,7 @@ def _clear_deeporigin_modules(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_import_config_does_not_create_deeporigin_dir(
-    blocked_home: Path,
+    blocked_home: pathlib.Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Importing deeporigin.config must not mkdir ~/.deeporigin."""
@@ -45,7 +47,7 @@ def test_import_config_does_not_create_deeporigin_dir(
 
 
 def test_import_platform_client_does_not_create_deeporigin_dir(
-    blocked_home: Path,
+    blocked_home: pathlib.Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Importing DeepOriginClient must not mkdir ~/.deeporigin."""

--- a/tests/test_import_side_effects.py
+++ b/tests/test_import_side_effects.py
@@ -1,0 +1,57 @@
+"""Regression tests for import-time side effects in config and platform client."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+import pytest
+
+
+def _blocked_home(tmp_path: Path) -> Path:
+    """Return a HOME path whose parent directory does not exist."""
+    return tmp_path / "missing" / "home"
+
+
+@pytest.fixture
+def blocked_home(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    """Point HOME at a path whose parent cannot be created implicitly."""
+    home = _blocked_home(tmp_path)
+    monkeypatch.setenv("HOME", str(home))
+    return home
+
+
+def _clear_deeporigin_modules(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Drop cached deeporigin modules so imports observe the patched HOME."""
+    for name in list(sys.modules):
+        if name.startswith("deeporigin"):
+            monkeypatch.delitem(sys.modules, name, raising=False)
+
+
+def test_import_config_does_not_create_deeporigin_dir(
+    blocked_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Importing deeporigin.config must not mkdir ~/.deeporigin."""
+    _clear_deeporigin_modules(monkeypatch)
+
+    import deeporigin.config as config_module
+
+    assert (
+        config_module.CONFIG_JSON_LOCATION
+        == blocked_home / ".deeporigin" / "config.json"
+    )
+    assert not (blocked_home / ".deeporigin").exists()
+
+
+def test_import_platform_client_does_not_create_deeporigin_dir(
+    blocked_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Importing DeepOriginClient must not mkdir ~/.deeporigin."""
+    _clear_deeporigin_modules(monkeypatch)
+
+    from deeporigin.platform.client import DeepOriginClient
+
+    assert DeepOriginClient is not None
+    assert not (blocked_home / ".deeporigin").exists()


### PR DESCRIPTION
## Summary

Importing `deeporigin_sdk.config` or `DeepOriginClient` (via `ToolsSDK`) no longer creates `~/.deeporigin` at import time. The config directory is created lazily when disk-backed configuration is actually read or written, fixing `PermissionError` in RBFE `guard-rbfe-outcomes` pods where `/home/app` does not exist.

**Jira:** [DDOS-6998](https://deeporigin.atlassian.net/browse/DDOS-6998)

## Test plan

- [x] `uv run pytest --env local tests/test_import_side_effects.py tests/test_config.py tests/test_platform_client_env.py`
- [ ] CI green on PR
- [ ] After SDK release, bump `deeporigin-sdk` pin in toolbox `tools-sdk`

Made with [Cursor](https://cursor.com)

[DDOS-6998]: https://deeporigin.atlassian.net/browse/DDOS-6998?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ